### PR TITLE
Add XHTMLDocHandler class unit test

### DIFF
--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -32,7 +32,8 @@ class XHTMLDocHandler(DocHandler):
 
         """
         cache_file_path = os.path.join(self.config.get_param("cache_dir"), "standard", cache_file_name)
-        if force_download or (not os.path.exists(cache_file_path)):
+        need_download = force_download or (not os.path.exists(cache_file_path))
+        if need_download:
             if not url:
                 raise ValueError("URL must be provided to download the file.")
             cache_file_path = self.download(url, cache_file_name)
@@ -82,6 +83,7 @@ class XHTMLDocHandler(DocHandler):
         response.raise_for_status()
         # Force UTF-8 decoding to avoid getting Ã (/u00C3) characters
         response.encoding = "utf-8"
+        # IN the future we may want to manually decode the content and ignore errors:
         # html_content = response.content.decode("utf-8", errors="ignore")
         # return html_content
         return response.text

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -1,3 +1,9 @@
+"""XHTML document handler class for DICOM standard processing in dcmspec.
+
+Provides the XHTMLDocHandler class for downloading, caching, and parsing XHTML documents
+from the DICOM standard, returning a BeautifulSoup DOM object.
+"""
+
 import os
 import re
 import requests
@@ -7,18 +13,23 @@ from dcmspec.doc_handler import DocHandler
 
 
 class XHTMLDocHandler(DocHandler):
+    """Handler class for DICOM specifications documents in XHTML format.
+
+    Provides methods to download, cache, and parse XHTML documents, returning a BeautifulSoup DOM object.
+    Inherits configuration and logging from DocHandler.
+    """
 
     def get_dom(self, cache_file_name: str, url: Optional[str] = None, force_download: bool = False) -> BeautifulSoup:
-        """
-        Opens and parses an XHTML file, downloading it if needed.
+        """Open and parse an XHTML file, downloading it if needed.
 
         Args:
-            file_path (str): Path to the local XHTML file.
-            url (str, optional): URL to download the file from if not present or force_download is True.
-            force_download (bool): If True, always download the file from the URL.
+            cache_file_name (str): Path to the local cached XHTML file.
+            url (str, optional): URL to download the file from if not cached or if force_download is True.
+            force_download (bool): If True, do not use cache and download the file from the URL.
 
         Returns:
             BeautifulSoup: Parsed DOM.
+
         """
         cache_file_path = os.path.join(self.config.get_param("cache_dir"), "standard", cache_file_name)
         if force_download or (not os.path.exists(cache_file_path)):
@@ -28,15 +39,7 @@ class XHTMLDocHandler(DocHandler):
         return self.parse_dom(cache_file_path)
 
     def download(self, url: str, cache_file_name: str) -> str:
-        """
-        Downloads an XHTML file from a URL and saves it to file_path.
-        Raises a RuntimeError if the download or save fails.
-
-        The URL from a Part of the DICOM standard in HTML or a Part section
-        in CHTML format containing Attributes tables is expected.
-
-        Retrieves the XHTML content and saves it to the given file path,
-        creating any necessary directories.
+        """Download and cache an XHTML file from a URL.
 
         Args:
             url: The URL of the XHTML document to download.
@@ -44,41 +47,65 @@ class XHTMLDocHandler(DocHandler):
 
         Returns:
             The file path where the document was saved.
+
+        Raises:
+            RuntimeError: If the download or save fails.
+
         """
         file_path = os.path.join(self.config.get_param("cache_dir"), "standard", cache_file_name)
         self.logger.info(f"Downloading XHTML document from {url} to {file_path}")
         try:
-            # Create the destination folder if it does not exist
-            dir_name = os.path.dirname(file_path)
-            if dir_name:
-                os.makedirs(dir_name, exist_ok=True)
-
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-
-            # Force UTF-8 decoding to avoid getting Ã (/u00C3) characters
-            response.encoding = "utf-8"
-            # html_content = response.content.decode("utf-8", errors="ignore")
-            html_content = response.text
-            with open(file_path, "w", encoding="utf-8") as f:
-                # Replace ZWSP with nothing and NBSP with a regular space
-                cleaned_content = re.sub(r"\u200b", "", html_content)
-                cleaned_content = re.sub(r"\u00a0", " ", cleaned_content)
-
-                f.write(cleaned_content)
+            self._ensure_dir_exists(file_path)  # Fail before download if directory can't be created
+        except OSError as e:
+            self.logger.error(f"Failed to create directory for {file_path}: {e}")
+            raise RuntimeError(f"Failed to create directory for {file_path}: {e}") from e
+        try:
+            html_content = self._fetch_url_content(url)
+            self._save_content(file_path, html_content)
             self.logger.info(f"Document downloaded to {file_path}")
             return file_path
         except requests.exceptions.RequestException as e:
             self.logger.error(f"Failed to download {url}: {e}")
-            raise RuntimeError(f"Failed to download {url}: {e}")
+            raise RuntimeError(f"Failed to download {url}: {e}") from e
         except OSError as e:
             self.logger.error(f"Failed to save file {file_path}: {e}")
-            raise RuntimeError(f"Failed to save file {file_path}: {e}")
+            raise RuntimeError(f"Failed to save file {file_path}: {e}") from e
+
+    def _ensure_dir_exists(self, file_path: str) -> None:
+        """Ensure the directory for the file path exists."""
+        if dir_name := os.path.dirname(file_path):
+            os.makedirs(dir_name, exist_ok=True)
+
+    def _fetch_url_content(self, url: str) -> str:
+        """Fetch content from a URL and return as UTF-8 text."""
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        # Force UTF-8 decoding to avoid getting Ã (/u00C3) characters
+        response.encoding = "utf-8"
+        # html_content = response.content.decode("utf-8", errors="ignore")
+        # return html_content
+        return response.text
+
+    def _save_content(self, file_path: str, html_content: str) -> None:
+        """Clean and save HTML content to a file."""
+        with open(file_path, "w", encoding="utf-8") as f:
+            # Replace ZWSP with nothing and NBSP with a regular space
+            cleaned_content = re.sub(r"\u200b", "", html_content)
+            cleaned_content = re.sub(r"\u00a0", " ", cleaned_content)
+            f.write(cleaned_content)
 
     def parse_dom(self, file_path: str) -> BeautifulSoup:
-        """
-        Parses a local XHTML file and returns a BeautifulSoup DOM.
-        Raises a RuntimeError if the file cannot be read or parsed.
+        """Parse a cached XHTML file into a BeautifulSoup DOM object.
+
+        Args:
+            file_path (str): Path to the cached XHTML file to parse.
+
+        Returns:
+            BeautifulSoup: The parsed DOM object.
+
+        Raises:
+            RuntimeError: If the file cannot be read or parsed.
+
         """
         self.logger.info(f"Reading XHTML DOM from {file_path}")
         try:
@@ -92,15 +119,22 @@ class XHTMLDocHandler(DocHandler):
             return dom
         except OSError as e:
             self.logger.error(f"Failed to read file {file_path}: {e}")
-            raise RuntimeError(f"Failed to read file {file_path}: {e}")
+            raise RuntimeError(f"Failed to read file {file_path}: {e}") from e
         except Exception as e:
             self.logger.error(f"Failed to parse XHTML file {file_path}: {e}")
-            raise RuntimeError(f"Failed to parse XHTML file {file_path}: {e}")
+            raise RuntimeError(f"Failed to parse XHTML file {file_path}: {e}") from e
 
-    def _patch_table(self, dom, table_id):
-        """
-        Patches the XHTML table to fix potential errors.
+    def _patch_table(self, dom: BeautifulSoup, table_id: str) -> None:
+        """Patch an XHTML table to fix potential errors.
 
         This method does nothing and may be overridden in derived classes if patching is needed.
+
+        Args:
+            dom (BeautifulSoup): The parsed XHTML DOM object.
+            table_id (str): The ID of the table to patch.
+
+        Returns:
+            None
+            
         """
         pass

--- a/tests/test_xhtml_doc_handler.py
+++ b/tests/test_xhtml_doc_handler.py
@@ -1,0 +1,277 @@
+"""Tests for the XHTMLDocHandler class in dcmspec.xhtml_doc_handler."""
+from bs4 import ParserRejectedMarkup
+import os
+import pytest
+from requests.exceptions import RequestException
+from dcmspec.xhtml_doc_handler import XHTMLDocHandler
+
+
+class DummyResponseSuccess:
+    """A dummy HTTP response object that simulates a successful requests.get call."""
+
+    def __init__(self):
+        """Initialize a successful dummy response."""
+        self.text = "test content"
+        self.status_code = 200
+        self.encoding = None
+    def raise_for_status(self):
+        """Simulate a successful status check (do nothing)."""
+        pass
+        
+class DummyResponseFailure:
+    """A dummy HTTP response object that simulates a failed requests.get call."""
+
+    def raise_for_status(self): 
+        """Simulate a failed request by raising an exception."""
+        raise RequestException("fail")
+
+def test_fetch_url_content_success(monkeypatch):
+    """Test that _fetch_url_content successfully downloads content."""
+    handler = XHTMLDocHandler()
+    # Patch request get method
+    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseSuccess())
+    # Check that response content is returned
+    assert handler._fetch_url_content("http://example.com") == "test content"
+
+def test_fetch_url_content_failure(monkeypatch):
+    """Test that _fetch_url_content successfully raises exception."""
+    handler = XHTMLDocHandler()
+    # Patch request get method
+    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseFailure())
+    # Check that request exception is raised
+    with pytest.raises(RequestException):
+        handler._fetch_url_content("http://example.com")
+
+def test_ensure_dir_exists_creates_directory():
+    """Test that _ensure_dir_exists successfully creates the directory specified in path."""
+    handler = XHTMLDocHandler()
+    # Use the patched cache directory as the base (patch_dirs is autouse)
+    cache_dir = handler.config.get_param("cache_dir")
+    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
+    dir_path = os.path.join(cache_dir, "standard")
+    assert not os.path.exists(dir_path)
+    handler._ensure_dir_exists(file_path)
+    assert os.path.exists(dir_path)
+
+def test_save_content_cleans_and_writes():
+    """Test that _save_content successfully cleans up and writes the content to the file."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
+    html_content = "A\u200bB\u00a0C"
+    # Ensure the directory exists before saving
+    handler._ensure_dir_exists(file_path)
+    handler._save_content(str(file_path), html_content)
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+    assert "\u200b" not in content
+    assert "\u00a0" not in content
+    assert "AB C" in content
+
+def mock_ensure_dir_exists(path, call_log):
+    """Mock _ensure_dir_exists method."""
+    call_log.append(("ensure_dir_exists", path))
+
+def mock_fetch_url_content(url, call_log):
+    """Mock _fetch_url_content method."""
+    call_log.append(("fetch_url_content", url))
+    return "<html>content</html>"
+
+def mock_save_content(path, content, call_log):
+    """Mock _save_content method."""
+    call_log.append(("save_content", path, content))
+
+def test_download_success(monkeypatch, caplog):
+    """Test that download calls helpers and logs info, and returns the correct file path."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_name = "test.xhtml"
+    file_path = os.path.join(cache_dir, "standard", file_name)
+
+    call_log = []
+
+    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: mock_ensure_dir_exists(path, call_log))
+    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: mock_fetch_url_content(url, call_log))
+    monkeypatch.setattr(handler, "_save_content", lambda path, content: mock_save_content(path, content, call_log))
+
+    with caplog.at_level("INFO"):
+        result = handler.download("http://example.com", file_name)
+
+    assert result == file_path
+    assert call_log == [
+        ("ensure_dir_exists", file_path),
+        ("fetch_url_content", "http://example.com"),
+        ("save_content", file_path, "<html>content</html>"),
+    ]
+    assert f"Downloading XHTML document from http://example.com to {file_path}" in caplog.text
+    assert f"Document downloaded to {file_path}" in caplog.text
+
+
+def fail_ensure_dir_exists(path):
+    """Mock _ensure_dir_exists that always fails."""
+    raise OSError("cannot create dir")
+
+def fail_fetch_url_content(url):
+    """Mock _fetch_url_content that always fails."""
+    raise RequestException("fetch failed")
+
+def fail_save_content(path, content):
+    """Mock _save_content that always fails."""
+    raise OSError("save failed")
+
+def test_download_ensure_dir_fails(monkeypatch, caplog):
+    """Test that download raises RuntimeError if _ensure_dir_exists fails."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_name = "test.xhtml"
+    file_path = os.path.join(cache_dir, "standard", file_name)
+
+    monkeypatch.setattr(handler, "_ensure_dir_exists", fail_ensure_dir_exists)
+    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: "<html>content</html>")
+    monkeypatch.setattr(handler, "_save_content", lambda path, content: None)
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+        handler.download("http://example.com", file_name)
+    assert "Failed to create directory for" in str(excinfo.value)
+    assert "cannot create dir" in str(excinfo.value)
+    assert f"Failed to create directory for {file_path}: cannot create dir" in caplog.text
+
+def test_download_fetch_url_fails(monkeypatch, caplog):
+    """Test that download raises RuntimeError if _fetch_url_content fails."""
+    handler = XHTMLDocHandler()
+    file_name = "test.xhtml"
+
+    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: None)
+    monkeypatch.setattr(handler, "_fetch_url_content", fail_fetch_url_content)
+    monkeypatch.setattr(handler, "_save_content", lambda path, content: None)
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+        handler.download("http://example.com", file_name)
+    assert "Failed to download http://example.com: fetch failed" in str(excinfo.value)
+    assert "Failed to download http://example.com: fetch failed" in caplog.text
+
+def test_download_save_content_fails(monkeypatch, caplog):
+    """Test that download raises RuntimeError if _save_content fails."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_name = "test.xhtml"
+    file_path = os.path.join(cache_dir, "standard", file_name)
+
+    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: None)
+    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: "<html>content</html>")
+    monkeypatch.setattr(handler, "_save_content", fail_save_content)
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+        handler.download("http://example.com", file_name)
+    assert "Failed to save file" in str(excinfo.value)
+    assert "save failed" in str(excinfo.value)
+    assert f"Failed to save file {file_path}: save failed" in caplog.text
+
+def test_parse_dom_success(tmp_path, caplog):
+    """Test that parse_dom reads and parses a valid XHTML file, logs info, and returns a BeautifulSoup object."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
+    # Ensure the directory exists and write a simple XHTML file
+    handler._ensure_dir_exists(file_path)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("<root><tag>ok</tag></root>")
+
+    with caplog.at_level("INFO"):
+        dom = handler.parse_dom(file_path)
+
+    assert dom.find("tag").text == "ok"
+    assert f"Reading XHTML DOM from {file_path}" in caplog.text
+    assert "XHTML DOM read successfully" in caplog.text
+
+def test_parse_dom_file_read_error(tmp_path, caplog):
+    """Test that parse_dom raises RuntimeError and logs error if file cannot be read."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_path = os.path.join(cache_dir, "standard", "nonexistent.xhtml")
+    # Do not create the file
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+        handler.parse_dom(file_path)
+    assert "Failed to read file" in str(excinfo.value)
+    assert f"Failed to read file {file_path}" in caplog.text
+
+def raise_bs4_parser_rejected_markup(*args, **kwargs):
+    """Mock BeautifulSoup to always raise a bs4.ParserRejectedMarkup error."""
+    raise ParserRejectedMarkup("Parser rejected markup.")
+
+def test_parse_dom_parse_error(tmp_path, caplog, monkeypatch):
+    """Test that parse_dom raises RuntimeError and logs error if file cannot be parsed."""
+    handler = XHTMLDocHandler()
+    cache_dir = handler.config.get_param("cache_dir")
+    file_path = os.path.join(cache_dir, "standard", "bad.xhtml")
+    handler._ensure_dir_exists(file_path)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("<root><tag>unclosed</root>")  # Malformed XML
+
+    # Patch the BeautifulSoup used in the xhtml_doc_handler module
+    monkeypatch.setattr("dcmspec.xhtml_doc_handler.BeautifulSoup", raise_bs4_parser_rejected_markup)
+
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+        handler.parse_dom(file_path)
+    assert "Failed to parse XHTML file" in str(excinfo.value)
+    assert f"Failed to parse XHTML file {file_path}" in caplog.text
+
+def test_get_dom_force_download(monkeypatch):
+    """Test that get_dom downloads and parses when force_download is True."""
+    handler = XHTMLDocHandler()
+    file_name = "file.xhtml"
+    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    call_log = []
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
+    monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    result = handler.get_dom(file_name, url="http://example.com", force_download=True)
+    assert result == "DOM_OBJECT"
+    assert call_log == ["download", "parse_dom"]
+
+def test_get_dom_file_missing(monkeypatch):
+    """Test that get_dom downloads and parses when file does not exist and force_download is False."""
+    handler = XHTMLDocHandler()
+    file_name = "file.xhtml"
+    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    call_log = []
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
+    monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    result = handler.get_dom(file_name, url="http://example.com", force_download=False)
+    assert result == "DOM_OBJECT"
+    assert call_log == ["download", "parse_dom"]
+
+def test_get_dom_file_exists(monkeypatch):
+    """Test that get_dom only parses when file exists and force_download is False."""
+    handler = XHTMLDocHandler()
+    file_name = "file.xhtml"
+    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    call_log = []
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
+    monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    result = handler.get_dom(file_name, url="http://example.com", force_download=False)
+    assert result == "DOM_OBJECT"
+    assert call_log == ["parse_dom"]
+
+def test_get_dom_force_download_missing_url(monkeypatch):
+    """Test that get_dom raises ValueError when force_download is True and url is missing."""
+    handler = XHTMLDocHandler()
+    file_name = "file.xhtml"
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: None)
+    monkeypatch.setattr(handler, "parse_dom", lambda path: None)
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    with pytest.raises(ValueError):
+        handler.get_dom(file_name, url=None, force_download=True)
+
+def test_get_dom_file_missing_missing_url(monkeypatch):
+    """Test that get_dom raises ValueError when file does not exist, force_download is False, and url is missing."""
+    handler = XHTMLDocHandler()
+    file_name = "file.xhtml"
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: None)
+    monkeypatch.setattr(handler, "parse_dom", lambda path: None)
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    with pytest.raises(ValueError):
+        handler.get_dom(file_name, url=None, force_download=False)

--- a/tests/test_xhtml_doc_handler.py
+++ b/tests/test_xhtml_doc_handler.py
@@ -1,17 +1,17 @@
 """Tests for the XHTMLDocHandler class in dcmspec.xhtml_doc_handler."""
 from bs4 import ParserRejectedMarkup
+from unittest.mock import patch
 import os
 import pytest
 from requests.exceptions import RequestException
 from dcmspec.xhtml_doc_handler import XHTMLDocHandler
-
 
 class DummyResponseSuccess:
     """A dummy HTTP response object that simulates a successful requests.get call."""
 
     def __init__(self):
         """Initialize a successful dummy response."""
-        self.text = "test content"
+        self.text = "A\u200bB\u00a0C"
         self.status_code = 200
         self.encoding = None
     def raise_for_status(self):
@@ -25,153 +25,83 @@ class DummyResponseFailure:
         """Simulate a failed request by raising an exception."""
         raise RequestException("fail")
 
-def test_fetch_url_content_success(monkeypatch):
-    """Test that _fetch_url_content successfully downloads content."""
+def _standard_file_path(handler, file_name):
+    """Return the standard file path for a given handler and file name."""
+    cache_dir = handler.config.get_param("cache_dir")
+    return os.path.join(cache_dir, "standard", file_name)
+
+def test_download_success(monkeypatch, caplog):
+    """Test that download calls helpers and logs info, and returns the correct file path."""
     handler = XHTMLDocHandler()
+    file_name = "test.xhtml"
+    file_path = _standard_file_path(handler, file_name)
+
     # Patch request get method
     monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseSuccess())
-    # Check that response content is returned
-    assert handler._fetch_url_content("http://example.com") == "test content"
 
-def test_fetch_url_content_failure(monkeypatch):
-    """Test that _fetch_url_content successfully raises exception."""
-    handler = XHTMLDocHandler()
-    # Patch request get method
-    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseFailure())
-    # Check that request exception is raised
-    with pytest.raises(RequestException):
-        handler._fetch_url_content("http://example.com")
+    # Call the download method
+    result_path = handler.download("http://example.com", file_name)
 
-def test_ensure_dir_exists_creates_directory():
-    """Test that _ensure_dir_exists successfully creates the directory specified in path."""
-    handler = XHTMLDocHandler()
-    # Use the patched cache directory as the base (patch_dirs is autouse)
-    cache_dir = handler.config.get_param("cache_dir")
-    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
-    dir_path = os.path.join(cache_dir, "standard")
-    assert not os.path.exists(dir_path)
-    handler._ensure_dir_exists(file_path)
-    assert os.path.exists(dir_path)
 
-def test_save_content_cleans_and_writes():
-    """Test that _save_content successfully cleans up and writes the content to the file."""
-    handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
-    html_content = "A\u200bB\u00a0C"
-    # Ensure the directory exists before saving
-    handler._ensure_dir_exists(file_path)
-    handler._save_content(str(file_path), html_content)
+    # Assert the file was created and contains the expected content
+    assert result_path == file_path
+    assert os.path.exists(file_path)
     with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
     assert "\u200b" not in content
     assert "\u00a0" not in content
     assert "AB C" in content
-
-def _mock_ensure_dir_exists(path, call_log):
-    """Mock _ensure_dir_exists method."""
-    call_log.append(("ensure_dir_exists", path))
-
-def _mock_fetch_url_content(url, call_log):
-    """Mock _fetch_url_content method."""
-    call_log.append(("fetch_url_content", url))
-    return "<html>content</html>"
-
-def _mock_save_content(path, content, call_log):
-    """Mock _save_content method."""
-    call_log.append(("save_content", path, content))
-
-def test_download_success(monkeypatch, caplog):
-    """Test that download calls helpers and logs info, and returns the correct file path."""
-    handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_name = "test.xhtml"
-    file_path = os.path.join(cache_dir, "standard", file_name)
-
-    call_log = []
-
-    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: _mock_ensure_dir_exists(path, call_log))
-    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: _mock_fetch_url_content(url, call_log))
-    monkeypatch.setattr(handler, "_save_content", lambda path, content: _mock_save_content(path, content, call_log))
-
-    with caplog.at_level("INFO"):
-        result = handler.download("http://example.com", file_name)
-
-    assert result == file_path
-    assert call_log == [
-        ("ensure_dir_exists", file_path),
-        ("fetch_url_content", "http://example.com"),
-        ("save_content", file_path, "<html>content</html>"),
-    ]
+    
     assert f"Downloading XHTML document from http://example.com to {file_path}" in caplog.text
     assert f"Document downloaded to {file_path}" in caplog.text
 
 
-def _mock_ensure_dir_exists_fails(path):
-    """Mock _ensure_dir_exists that always fails."""
-    raise OSError("cannot create dir")
-
-def _mock_fetch_url_content_fails(url):
-    """Mock _fetch_url_content that always fails."""
-    raise RequestException("fetch failed")
-
-def _mock_save_content_fails(path, content):
-    """Mock _save_content that always fails."""
-    raise OSError("save failed")
-
-def test_download_ensure_dir_fails(monkeypatch, caplog):
-    """Test that download raises RuntimeError if _ensure_dir_exists fails."""
+def test_download_failure_network(tmp_path, monkeypatch):
+    """Test that download raises RuntimeError on network error."""
     handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
+    handler.config.set_param("cache_dir", str(tmp_path))
     file_name = "test.xhtml"
-    file_path = os.path.join(cache_dir, "standard", file_name)
+    _standard_file_path(handler, file_name)
 
-    monkeypatch.setattr(handler, "_ensure_dir_exists", _mock_ensure_dir_exists_fails)
-    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: "<html>content</html>")
-    monkeypatch.setattr(handler, "_save_content", lambda path, content: None)
+    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseFailure())
 
-    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
+        handler.download("http://example.com", file_name)
+    assert "Failed to download" in str(excinfo.value)
+
+def test_download_failure_dir(monkeypatch):  # sourcery skip: simplify-generator
+    """Test that download raises RuntimeError if directory creation fails."""
+    handler = XHTMLDocHandler()
+    file_name = "test.xhtml"
+
+    # Patch os.makedirs to always raise OSError
+    monkeypatch.setattr("os.makedirs", lambda *a, **k: (_ for _ in ()).throw(OSError("cannot create dir")))
+
+    with pytest.raises(RuntimeError) as excinfo:
         handler.download("http://example.com", file_name)
     assert "Failed to create directory for" in str(excinfo.value)
     assert "cannot create dir" in str(excinfo.value)
-    assert f"Failed to create directory for {file_path}: cannot create dir" in caplog.text
 
-def test_download_fetch_url_fails(monkeypatch, caplog):
-    """Test that download raises RuntimeError if _fetch_url_content fails."""
+def test_download_failure_save(monkeypatch):
+    """Test that download raises RuntimeError if saving the file fails."""
     handler = XHTMLDocHandler()
     file_name = "test.xhtml"
 
-    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: None)
-    monkeypatch.setattr(handler, "_fetch_url_content", _mock_fetch_url_content_fails)
-    monkeypatch.setattr(handler, "_save_content", lambda path, content: None)
+    # Patch requests.get to return a successful dummy response
+    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponseSuccess())
 
-    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
-        handler.download("http://example.com", file_name)
-    assert "Failed to download http://example.com: fetch failed" in str(excinfo.value)
-    assert "Failed to download http://example.com: fetch failed" in caplog.text
-
-def test_download_save_content_fails(monkeypatch, caplog):
-    """Test that download raises RuntimeError if _save_content fails."""
-    handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_name = "test.xhtml"
-    file_path = os.path.join(cache_dir, "standard", file_name)
-
-    monkeypatch.setattr(handler, "_ensure_dir_exists", lambda path: None)
-    monkeypatch.setattr(handler, "_fetch_url_content", lambda url: "<html>content</html>")
-    monkeypatch.setattr(handler, "_save_content", _mock_save_content_fails)
-
-    with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
-        handler.download("http://example.com", file_name)
+    # Patch builtins.open only for download call
+    with patch("builtins.open", side_effect=OSError("save failed")):
+        with pytest.raises(RuntimeError) as excinfo:
+            handler.download("http://example.com", file_name)
     assert "Failed to save file" in str(excinfo.value)
     assert "save failed" in str(excinfo.value)
-    assert f"Failed to save file {file_path}: save failed" in caplog.text
 
 def test_parse_dom_success(tmp_path, caplog):
     """Test that parse_dom reads and parses a valid XHTML file, logs info, and returns a BeautifulSoup object."""
     handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_path = os.path.join(cache_dir, "standard", "file.xhtml")
+    file_path = _standard_file_path(handler, "file.xhtml")
+
     # Ensure the directory exists and write a simple XHTML file
     handler._ensure_dir_exists(file_path)
     with open(file_path, "w", encoding="utf-8") as f:
@@ -187,8 +117,7 @@ def test_parse_dom_success(tmp_path, caplog):
 def test_parse_dom_file_read_error(tmp_path, caplog):
     """Test that parse_dom raises RuntimeError and logs error if file cannot be read."""
     handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_path = os.path.join(cache_dir, "standard", "nonexistent.xhtml")
+    file_path = _standard_file_path(handler, "nonexistent.xhtml")
     # Do not create the file
 
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError) as excinfo:
@@ -203,8 +132,8 @@ def raise_bs4_parser_rejected_markup(*args, **kwargs):
 def test_parse_dom_parse_error(tmp_path, caplog, monkeypatch):
     """Test that parse_dom raises RuntimeError and logs error if file cannot be parsed."""
     handler = XHTMLDocHandler()
-    cache_dir = handler.config.get_param("cache_dir")
-    file_path = os.path.join(cache_dir, "standard", "bad.xhtml")
+    file_path = _standard_file_path(handler, "bad.xhtml")
+
     handler._ensure_dir_exists(file_path)
     with open(file_path, "w", encoding="utf-8") as f:
         f.write("<root><tag>unclosed</root>")  # Malformed XML
@@ -221,7 +150,7 @@ def test_get_dom_force_download(monkeypatch):
     """Test that get_dom downloads and parses when force_download is True."""
     handler = XHTMLDocHandler()
     file_name = "file.xhtml"
-    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    file_path = _standard_file_path(handler, file_name)
     call_log = []
     monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
     monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")
@@ -234,7 +163,7 @@ def test_get_dom_file_missing(monkeypatch):
     """Test that get_dom downloads and parses when file does not exist and force_download is False."""
     handler = XHTMLDocHandler()
     file_name = "file.xhtml"
-    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    file_path = _standard_file_path(handler, file_name)
     call_log = []
     monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
     monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")
@@ -247,7 +176,7 @@ def test_get_dom_file_exists(monkeypatch):
     """Test that get_dom only parses when file exists and force_download is False."""
     handler = XHTMLDocHandler()
     file_name = "file.xhtml"
-    file_path = os.path.join(handler.config.get_param("cache_dir"), "standard", file_name)
+    file_path = _standard_file_path(handler, file_name)
     call_log = []
     monkeypatch.setattr(handler, "download", lambda url, cache_file_name: call_log.append("download") or file_path)
     monkeypatch.setattr(handler, "parse_dom", lambda path: call_log.append("parse_dom") or "DOM_OBJECT")


### PR DESCRIPTION
- Add unit test cases for each method in html_doc_handler.py
- Improve docstrings in xhtml_doc_handler.py

## Summary by Sourcery

Refactor XHTMLDocHandler to improve modularity and documentation, and add extensive unit tests to validate its download, caching, and parsing functionality.

Enhancements:
- Refactor download method by extracting directory creation, URL fetching, and content saving into _ensure_dir_exists, _fetch_url_content, and _save_content helpers
- Improve and enrich docstrings for XHTMLDocHandler and its methods, adding detailed Args, Returns, and Raises sections
- Add exception chaining for clearer error propagation in download and parse_dom

Tests:
- Add comprehensive unit tests for _fetch_url_content, _ensure_dir_exists, _save_content, download, parse_dom, and get_dom covering success, failure, and edge cases