### PR TITLE
Add DOMTableSpecParser class unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist/
 .pytest_cache/
 .coverage
 
+# sourcery
+.sourcery.yaml
+
 # cache folder for standards inputs and model outputs
 cache/
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ dist/
 .pytest_cache/
 .coverage
 
-# sourcery
-.sourcery.yaml
-
 # cache folder for standards inputs and model outputs
 cache/
 

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,38 @@
+ignore:
+  - .git
+  - venv
+  - .venv
+  - env
+  - .env
+  - .tox
+  - node_modules
+  - vendor
+
+rule_settings:
+  enable: [default]
+  disable: [use-named-expression]
+  rule_types:
+    - refactoring
+    - suggestion
+    - comment
+  python_version: "3.9"
+
+rules: []
+
+metrics:
+  quality_threshold: 25.0
+
+github:
+  labels: []
+  ignore_labels:
+    - sourcery-ignore
+  request_review: author
+  sourcery_branch: sourcery/{base_branch}
+
+clone_detection:
+  min_lines: 3
+  min_duplicates: 2
+  identical_clones_only: false
+
+proxy:
+  no_ssl_verify: false

--- a/src/dcmspec/doc_handler.py
+++ b/src/dcmspec/doc_handler.py
@@ -1,6 +1,6 @@
-"""Document handler base class for DICOM document processing in dcmspec.
+"""Abstract base class for handling DICOM document processing in dcmspec.
 
-Defines the DocHandler abstract base class for reading, parsing, and downloading DICOM documents.
+Defines the DocHandler interface for reading, parsing, and downloading DICOM documents.
 """
 from typing import Any, Optional
 import logging
@@ -12,8 +12,8 @@ from dcmspec.config import Config
 class DocHandler(ABC):
     """Abstract base class for DICOM document handlers.
 
-    The DICOM documents may be in various formats (e.g., XHTML, XML, etc.).
-    Subclasses must implement the `read_dom` and `download` methods to handle
+    Handles DICOM documents in various formats (e.g., XHTML, XML).
+    Subclasses must implement the `get_dom` and `download` methods to handle
     reading/parsing input files and downloading files from URLs.
     """
 

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -5,7 +5,7 @@ from dcmspec.config import Config
 from dcmspec.spec_model import SpecModel
 from dcmspec.xhtml_doc_handler import XHTMLDocHandler
 from dcmspec.json_spec_store import JSONSpecStore
-from dcmspec.dom_spec_parser import DOMSpecParser
+from dcmspec.dom_table_spec_parser import DOMTableSpecParser
 
 
 class SpecFactory:
@@ -13,7 +13,7 @@ class SpecFactory:
         self,
         input_handler: Optional[XHTMLDocHandler] = None,
         model_store: Optional[JSONSpecStore] = None,
-        table_parser: Optional[DOMSpecParser] = None,
+        table_parser: Optional[DOMTableSpecParser] = None,
         column_to_attr: Dict[int, str] = None,
         name_attr: str = None,
         config: Optional[Config] = None,
@@ -24,7 +24,7 @@ class SpecFactory:
 
         self.input_handler = input_handler or XHTMLDocHandler(config=self.config)
         self.model_store = model_store or JSONSpecStore()
-        self.table_parser = table_parser or DOMSpecParser()
+        self.table_parser = table_parser or DOMTableSpecParser()
         self.column_to_attr = column_to_attr or {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"}
         self.name_attr = name_attr or "elem_name"
 

--- a/src/dcmspec/spec_parser.py
+++ b/src/dcmspec/spec_parser.py
@@ -1,34 +1,37 @@
+"""Abstract base class for DICOM specification parsers in dcmspec.
+
+Defines the SpecParser interface for parsing in-memory representations of DICOM specifications.
+"""
 from abc import ABC, abstractmethod
+from anytree import Node
+from typing import Optional, Tuple
 import logging
-from typing import Optional
 
 
 class SpecParser(ABC):
-    """
-    Abstract base class for DICOM specification parsers.
+    """Abstract base class for DICOM specification parsers.
 
-    The DICOM Specification may be in various formats (e.g., DOM, CSV, etc.).
-    Subclasses must implement the `parse` method to parse specification contents and build
-    a representation of the specification metadata and content.
+    Handles DICOM specifications in various in-memory formats (e.g., DOM for XHTML/XML, CSV).
+    Subclasses must implement the `parse` method to parse the specification content and build a structured model.
     """
 
     def __init__(self, logger: Optional[logging.Logger] = None):
-        """
-        Initializes the DICOM Specification parser with an optional logger.
+        """Initialize the DICOM Specification parser with an optional logger.
 
         Args:
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
+
         """
         if logger is not None and not isinstance(logger, logging.Logger):
             raise TypeError("logger must be an instance of logging.Logger or None")
         self.logger = logger or logging.getLogger(self.__class__.__name__)
 
     @abstractmethod
-    def parse_table(self, source):
-        """
-        Parses a DICOM Specification from source data.
+    def parse(self, *args, **kwargs) -> Tuple[Node, Node]:
+        """Parse the DICOM specification and return metadata and attribute tree nodes.
 
-        Args:
-            source : DICOM Specification data.
+        Returns:
+            Tuple[Node, Node]: The metadata node and the content node.
+
         """
         pass

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -74,7 +74,8 @@ class XHTMLDocHandler(DocHandler):
 
     def _ensure_dir_exists(self, file_path: str) -> None:
         """Ensure the directory for the file path exists."""
-        if dir_name := os.path.dirname(file_path):
+        dir_name = os.path.dirname(file_path)
+        if dir_name:
             os.makedirs(dir_name, exist_ok=True)
 
     def _fetch_url_content(self, url: str) -> str:

--- a/tests/fixtures_dom_tables.py
+++ b/tests/fixtures_dom_tables.py
@@ -1,0 +1,306 @@
+import pytest
+from bs4 import BeautifulSoup
+
+@pytest.fixture
+def docbook_sample_dom_1():
+    """Return a BeautifulSoup DOM mimicking DICOM DocBook in CHTML."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <table width="100%">
+                <tbody>
+                    <tr>
+                        <th colspan="1" align="center" rowspan="1">
+                            <span class="documentreleaseinformation">DICOM PS3.3 2025b - Information Object Definitions</span>
+                        </th>
+                    </tr>
+                </tbody>
+            </table>
+            <div class="section">
+            <div class="titlepage">
+                <h4 class="title">
+                <a id="sect_SAMPLE" shape="rect"></a>Sample Section
+                </h4>
+            </div>
+            <div class="table">
+                <a id="table_SAMPLE" shape="rect"></a>
+                <p class="title"><strong>Table SAMPLE. Sample Attributes</strong></p>
+                <div class="table-contents">
+                <table frame="box" rules="all">
+                    <thead>
+                    <tr valign="top">
+                        <th align="center"><p>Attr Name</p></th>
+                        <th align="center"><p>Tag</p></th>
+                        <th align="center"><p>Type</p></th>
+                        <th align="center"><p>Description</p></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr valign="top">
+                        <td align="left"><p>AttrName1</p></td>
+                        <td align="center"><p>(0101,0001)</p></td>
+                        <td align="center"><p>1</p></td>
+                        <td align="left"><p>Desc1</p></td>
+                    </tr>
+                    <tr valign="top">
+                        <td align="left"><p>AttrName2</p></td>
+                        <td align="center"><p>(0101,0002)</p></td>
+                        <td align="center"><p>2</p></td>
+                        <td align="left"><p>Desc2</p></td>
+                    </tr>
+                    </tbody>
+                </table>
+                </div>
+            </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")
+
+
+@pytest.fixture
+def docbook_sample_dom_2():
+    """Return a BeautifulSoup DOM mimicking DICOM DocBook in HTML."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div class="titlepage">
+                <div>
+                    <div font-size="14pt">
+                        <h1 class="title">
+                            <a id="PS3.3" shape="rect"></a>PS3.3</h1>
+                    </div>
+                    <div font-size="14pt">
+                        <h2 class="subtitle">DICOM PS3.3 2025b - Information Object Definitions</h2>
+                    </div>
+                </div>
+            </div>
+            <div class="section">
+            <div class="titlepage">
+                <h4 class="title">
+                <a id="sect_SAMPLE" shape="rect"></a>Sample Section
+                </h4>
+            </div>
+            <div class="table">
+                <a id="table_SAMPLE" shape="rect"></a>
+                <p class="title"><strong>Table SAMPLE. Sample Attributes</strong></p>
+                <div class="table-contents">
+                <table frame="box" rules="all">
+                    <thead>
+                    <tr valign="top">
+                        <th align="center"><p>Attr Name</p></th>
+                        <th align="center"><p>Tag</p></th>
+                        <th align="center"><p>Type</p></th>
+                        <th align="center"><p>Description</p></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr valign="top">
+                        <td align="left"><p>AttrName1</p></td>
+                        <td align="center"><p>(0101,0001)</p></td>
+                        <td align="center"><p>1</p></td>
+                        <td align="left"><p>Desc1</p></td>
+                    </tr>
+                    <tr valign="top">
+                        <td align="left"><p>AttrName2</p></td>
+                        <td align="center"><p>(0101,0002)</p></td>
+                        <td align="center"><p>2</p></td>
+                        <td align="left"><p>Desc2</p></td>
+                    </tr>
+                    </tbody>
+                </table>
+                </div>
+            </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")
+
+@pytest.fixture
+def table_colspan_dom():
+    """Return a DocBook-style XHTML DOM with a table that uses colspan."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div class="section">
+                <div class="table">
+                    <a id="table_COLSPAN" shape="rect"></a>
+                    <p class="title"><strong>Table COLSPAN. Colspan Table</strong></p>
+                    <div class="table-contents">
+                        <table frame="box" rules="all">
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center"><p>Col1</p></th>
+                                    <th align="center"><p>Col2</p></th>
+                                    <th align="center"><p>Col3</p></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td colspan="2"><p>A</p></td>
+                                    <td><p>B</p></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")
+
+@pytest.fixture
+def table_rowspan_dom():
+    """Return a DocBook-style XHTML DOM with a table that uses rowspan."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div class="section">
+                <div class="table">
+                    <a id="table_ROWSPAN" shape="rect"></a>
+                    <p class="title"><strong>Table ROWSPAN. Rowspan Table</strong></p>
+                    <div class="table-contents">
+                        <table frame="box" rules="all">
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center"><p>Col1</p></th>
+                                    <th align="center"><p>Col2</p></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td rowspan="2"><p>A</p></td>
+                                    <td><p>B</p></td>
+                                </tr>
+                                <tr valign="top">
+                                    <td><p>C</p></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")
+
+@pytest.fixture
+def table_colspan_rowspan_dom():
+    """Return a DocBook-style XHTML DOM with a table that uses both colspan and rowspan."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div class="section">
+                <div class="table">
+                    <a id="table_COLSPANROWSPAN" shape="rect"></a>
+                    <p class="title"><strong>Table COLSPANROWSPAN. Colspan+Rowspan Table</strong></p>
+                    <div class="table-contents">
+                        <table frame="box" rules="all">
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center"><p>Col1</p></th>
+                                    <th align="center"><p>Col2</p></th>
+                                    <th align="center"><p>Col3</p></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td rowspan="2" colspan="2"><p>A</p></td>
+                                    <td><p>B</p></td>
+                                </tr>
+                                <tr valign="top">
+                                    <td><p>C</p></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")
+
+@pytest.fixture
+def table_include_dom():
+    """Return a BeautifulSoup DOM mimicking DocBook XHTML with an include row and a macro table."""
+    xhtml = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+        <body>
+            <div class="section">
+                <div class="table">
+                    <a id="table_MAIN" shape="rect"></a>
+                    <p class="title"><strong>Table MAIN. Main Table</strong></p>
+                    <div class="table-contents">
+                        <table frame="box" rules="all">
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center"><p>Col1</p></th>
+                                    <th align="center"><p>Col2</p></th>
+                                    <th align="center"><p>Col3</p></th>
+                                    <th align="center"><p>Col4</p></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left"><p>AttrName1</p></td>
+                                    <td align="center"><p>(0101,0001)</p></td>
+                                    <td align="center"><p>1</p></td>
+                                    <td align="left"><p>Desc1</p></td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left"><p>AttrName2</p></td>
+                                    <td align="center"><p>(0101,0002)</p></td>
+                                    <td align="center"><p>2</p></td>
+                                    <td align="left"><p>Desc2</p></td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left" colspan="4" rowspan="1">
+                                        <p>
+                                            <span class="italic">Include <a class="xref" href="#table_MACRO">Table Macro</a></span>
+                                        </p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="table">
+                    <a id="table_MACRO" shape="rect"></a>
+                    <p class="title"><strong>Table MACRO. Macro Table</strong></p>
+                    <div class="table-contents">
+                        <table frame="box" rules="all">
+                            <thead>
+                                <tr valign="top">
+                                    <th align="center"><p>Attr Name</p></th>
+                                    <th align="center"><p>Tag</p></th>
+                                    <th align="center"><p>Type</p></th>
+                                    <th align="center"><p>Description</p></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr valign="top">
+                                    <td align="left"><p>AttrName10</p></td>
+                                    <td align="center"><p>(0101,0010)</p></td>
+                                    <td align="center"><p>3</p></td>
+                                    <td align="left"><p>Bla</p></td>
+                                </tr>
+                                <tr valign="top">
+                                    <td align="left"><p>AttrName11</p></td>
+                                    <td align="center"><p>(0101,0011)</p></td>
+                                    <td align="center"><p>3</p></td>
+                                    <td align="left"><p>Bla</p></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </body>
+    </html>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")

--- a/tests/fixtures_dom_tables.py
+++ b/tests/fixtures_dom_tables.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 
 @pytest.fixture
 def docbook_sample_dom_1():
-    """Return a BeautifulSoup DOM mimicking DICOM DocBook in CHTML."""
+    """Return a BeautifulSoup DOM mimicking DICOM DocBook in CHTML, with a name to test _sanitize_string."""
     xhtml = """
     <html xmlns="http://www.w3.org/1999/xhtml">
         <body>
@@ -37,7 +37,7 @@ def docbook_sample_dom_1():
                     </thead>
                     <tbody>
                     <tr valign="top">
-                        <td align="left"><p>AttrName1</p></td>
+                        <td align="left"><p>Attr Name (Tést)</p></td>
                         <td align="center"><p>(0101,0001)</p></td>
                         <td align="center"><p>1</p></td>
                         <td align="left"><p>Desc1</p></td>

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -1,0 +1,200 @@
+"""Tests for the DOMTableSpecParser class in dcmspec.dom_table_spec_parser."""
+
+import pytest
+from anytree import Node
+from bs4 import BeautifulSoup
+from dcmspec.dom_table_spec_parser import DOMTableSpecParser
+
+# Import sample DOM with tables fixtures and disable ruff checks as fixtures import triggers false positive warnings
+from .fixtures_dom_tables import (
+    docbook_sample_dom_1,  # noqa: F401
+    docbook_sample_dom_2,  # noqa: F401
+    table_colspan_dom,  # noqa: F401
+    table_rowspan_dom,  # noqa: F401
+    table_colspan_rowspan_dom, # noqa: F401
+    table_include_dom,  # noqa: F401
+)
+
+def test_parse_table_returns_node(docbook_sample_dom_1):  # noqa: F811
+    """Test that parse_table returns a Node with correct children."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
+    node = parser.parse_table(
+        dom=docbook_sample_dom_1,
+        table_id="table_SAMPLE",
+        column_to_attr=column_to_attr,
+        name_attr="elem_name"
+    )
+    children = list(node.children)
+    assert len(children) == 2
+    assert children[0].elem_name == "AttrName1"
+    assert children[0].elem_tag == "(0101,0001)"
+    assert children[0].elem_type == "1"
+    assert children[0].elem_desc == "Desc1"
+    assert children[1].elem_name == "AttrName2"
+    assert children[1].elem_tag == "(0101,0002)"
+    assert children[1].elem_type == "2"
+    assert children[1].elem_desc == "Desc2"
+
+@pytest.mark.parametrize(
+    "fixture_name, expected_version",
+    [
+        ("docbook_sample_dom_1", "2025b"),
+        ("docbook_sample_dom_2", "2025b"),
+    ]
+)
+def test_parse_metadata_returns_node(request, fixture_name, expected_version):
+    """Test that parse_metadata returns a Node with version and header."""
+    parser = DOMTableSpecParser()
+    dom = request.getfixturevalue(fixture_name)
+    column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    node = parser.parse_metadata(
+        dom=dom,
+        table_id="table_SAMPLE",
+        column_to_attr=column_to_attr
+    )
+    assert isinstance(node, Node)
+    assert hasattr(node, "version")
+    assert hasattr(node, "header")
+    assert node.version == expected_version
+    assert node.header == ["Attr Name", "Tag"]
+
+def test_parse_table_missing_table_raises(docbook_sample_dom_1):  # noqa: F811
+    """Test that parse_table raises ValueError if table is not found."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    with pytest.raises(ValueError):
+        parser.parse_table(
+            dom=docbook_sample_dom_1,
+            table_id="not_a_table",
+            column_to_attr=column_to_attr,
+            name_attr="elem_name"
+        )
+
+def test_parse_table_missing_column_to_attr_raises(docbook_sample_dom_1):  # noqa: F811
+    """Test that parse_table raises ValueError if column_to_attr is missing."""
+    parser = DOMTableSpecParser()
+    with pytest.raises(ValueError):
+        parser.parse_table(
+            dom=docbook_sample_dom_1,
+            table_id="test_table",
+            column_to_attr={},
+            name_attr="elem_name"
+        )
+
+def test_parse_returns_metadata_and_content(docbook_sample_dom_1):  # noqa: F811
+    """Test that parse returns a tuple of (metadata, content) nodes."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
+    metadata, content = parser.parse(
+        dom=docbook_sample_dom_1,
+        table_id="table_SAMPLE",
+        column_to_attr=column_to_attr,
+        name_attr="elem_name"
+    )
+    assert isinstance(metadata, Node)
+    assert isinstance(content, Node)
+    assert hasattr(metadata, "header")
+    assert hasattr(metadata, "version")
+    assert metadata.version == "2025b"
+    children = list(content.children)
+    assert len(children) == 2
+    assert children[0].elem_name == "AttrName1"
+    assert children[1].elem_name == "AttrName2"
+
+
+
+def test_parse_table_colspan(table_colspan_dom):  # noqa: F811
+    """Test parse_table handles colspan correctly."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3"}
+    node = parser.parse_table(
+        dom=table_colspan_dom,
+        table_id="table_COLSPAN",
+        column_to_attr=column_to_attr,
+        name_attr="col1"
+    )
+    children = list(node.children)
+    assert len(children) == 1
+    assert children[0].col1 == "A"
+    # col2 is skipped due to colspan, col3 is B
+    assert children[0].col3 == "B"
+
+def test_parse_table_rowspan(table_rowspan_dom):  # noqa: F811
+    """Test parse_table handles rowspan correctly."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2"}
+    node = parser.parse_table(
+        dom=table_rowspan_dom,
+        table_id="table_ROWSPAN",
+        column_to_attr=column_to_attr,
+        name_attr="col1"
+    )
+    children = list(node.children)
+    assert len(children) == 2
+    assert children[0].col1 == "A"
+    assert children[0].col2 == "B"
+    assert children[1].col1 == "A"  # from rowspan
+    assert children[1].col2 == "C"
+
+def test_parse_table_colspan_rowspan(table_colspan_rowspan_dom):  # noqa: F811
+    """Test parse_table handles both colspan and rowspan together."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3"}
+    node = parser.parse_table(
+        dom=table_colspan_rowspan_dom,
+        table_id="table_COLSPANROWSPAN",
+        column_to_attr=column_to_attr,
+        name_attr="col1"
+    )
+    children = list(node.children)
+    assert len(children) == 2
+    assert children[0].col1 == "A"
+    assert children[0].col3 == "B"
+    assert children[1].col1 == "A"  # from rowspan+colspan
+    assert children[1].col3 == "C"
+
+
+def test_parse_table_include_triggers_recursion(table_include_dom):  # noqa: F811
+    """Test that parse_table handles an 'Include' row and recursively parses the included table."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3", 3: "col4"}
+    node = parser.parse_table(
+        dom=table_include_dom,
+        table_id="table_MAIN",
+        column_to_attr=column_to_attr,
+        name_attr="col1"
+    )
+    children = list(node.children)
+    # The root should have 4 children: AttrName1, AttrName2, AttrName10, AttrName11
+    assert len(children) == 4
+    assert children[0].col1 == "AttrName1"
+    assert children[1].col1 == "AttrName2"
+    assert children[2].col1 == "AttrName10"
+    assert children[3].col1 == "AttrName11"
+
+def test_parse_table_include_with_gt_nests_under_previous(table_include_dom):  # noqa: F811
+    # sourcery skip: extract-duplicate-method
+    """Test that parse_table nests included table rows under the previous node if '>' is present before Include."""
+    # Modify the fixture to use '>Include' instead of 'Include'
+    html = str(table_include_dom)
+    html = html.replace("Include <a", "&gt;Include <a")
+    dom = BeautifulSoup(html, "lxml-xml")
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3", 3: "col4"}
+    node = parser.parse_table(
+        dom=dom,
+        table_id="table_MAIN",
+        column_to_attr=column_to_attr,
+        name_attr="col1"
+    )
+    children = list(node.children)
+    # The root should have 2 children: AttrName1 and AttrName2
+    assert len(children) == 2
+    assert children[0].col1 == "AttrName1"
+    assert children[1].col1 == "AttrName2"
+    # The included table rows should be children of AttrName2
+    included_children = list(children[1].children)
+    assert len(included_children) == 2
+    assert included_children[0].col1 == ">AttrName10"
+    assert included_children[1].col1 == ">AttrName11"


### PR DESCRIPTION
- Add unit test cases for methodsin dom_table_spec_parser.py
- Improve docstrings in dom_table_spec_parser.py
- Update docstrings in doc_handler modules
- Add sourcery configuration to avoid named expressions walrus operator
- Update .gitignore for sourcery configuration

## Summary by Sourcery

Refactor and enrich the DOM table parsing API by renaming and enhancing DOMTableSpecParser, improving parsing logic and documentation, integrating it into the SpecFactory, and adding an extensive unit test suite and sourcery configuration.

New Features:
- Add comprehensive unit tests and fixtures for DOMTableSpecParser covering metadata extraction, table parsing, colspan/rowspan handling, and include recursion

Enhancements:
- Rename DOMSpecParser to DOMTableSpecParser and update SpecFactory to use the new class
- Enrich docstrings in dom_table_spec_parser, spec_parser, and doc_handler modules
- Streamline version extraction logic and enhance row data parsing (handle missing <p> tags and optimize rowspan tracking)
- Update abstract SpecParser.parse signature to return metadata and content tree nodes

Documentation:
- Improve user-facing docstrings in dom_table_spec_parser, spec_parser, doc_handler, and xhtml_doc_handler

Tests:
- Add fixtures in tests/fixtures_dom_tables.py and tests/test_dom_table_spec_parser.py for various table scenarios

Chores:
- Introduce Sourcery configuration and update .gitignore to support it