### PR TITLE
Add IODSpecBuilder class

### DIFF
--- a/src/dcmspec/cli/dataelements.py
+++ b/src/dcmspec/cli/dataelements.py
@@ -30,7 +30,7 @@ def main():
     )
 
     # Download, parse, and cache the model
-    model = factory.from_url(
+    model = factory.create_model(
         url=url,
         cache_file_name=cache_file_name,
         table_id=table_id,

--- a/src/dcmspec/cli/modattributes.py
+++ b/src/dcmspec/cli/modattributes.py
@@ -13,6 +13,29 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("table", help="Table ID")
     parser.add_argument("--config", help="Path to the configuration file")
+    parser.add_argument(
+        "--include-depth",
+        type=int,
+        default=None,
+        help="Depth to which included tables should be parsed (default: unlimited)"
+    )
+    parser.add_argument(
+        "--force-parse",
+        action="store_true",
+        help="Force reparsing of the DOM and regeneration of the JSON model, even if the JSON cache exists"
+    )    
+    parser.add_argument(
+        "--force-download",
+        action="store_true",
+        help="Force download of the input file and regeneration of the model, even if cached"
+    )
+    parser.add_argument(
+        "--print-mode",
+        choices=["table", "tree", "none"],
+        default="table",
+        help="Print as 'table' (default), 'tree', or 'none' to skip printing"
+    )
+
     args = parser.parse_args()
 
     cache_file_name = "Part3.xhtml"
@@ -33,17 +56,22 @@ def main():
     )
 
     # Download, parse, and cache the model
-    model = factory.from_url(
+    model = factory.create_model(
         url=url,
         cache_file_name=cache_file_name,
         json_file_name=model_file_name,
         table_id=table_id,
-        force_download=False,
+        force_parse=args.force_parse,
+        force_download=args.force_download,
+        include_depth=args.include_depth,
     )
 
-    # Print the model as a table
     printer = SpecPrinter(model)
-    printer.print_table(colorize=True)
+    if args.print_mode == "tree":
+        printer.print_tree(colorize=True)
+    elif args.print_mode == "table":
+        printer.print_table(colorize=True)
+    # else: do not print anything if print_mode == "none"
 
 
 if __name__ == "__main__":

--- a/src/dcmspec/cli/uidvalues.py
+++ b/src/dcmspec/cli/uidvalues.py
@@ -32,7 +32,7 @@ def main():
     )
 
     # Download, parse, and cache the model
-    model = factory.from_url(
+    model = factory.create_model(
         url=url,
         cache_file_name=cache_file_name,
         json_file_name=model_file_name,

--- a/src/dcmspec/cli/upsattributes.py
+++ b/src/dcmspec/cli/upsattributes.py
@@ -40,7 +40,7 @@ def main():
     )
 
     # Download, parse, and cache the model
-    model = factory.from_url(
+    model = factory.create_model(
         url=url,
         cache_file_name=cache_file_name,
         table_id=table_id,

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -205,6 +205,46 @@ class DOMTableSpecParser(SpecParser):
             return None
         return table
 
+    def get_table_id_from_section(self, dom: BeautifulSoup, section_id: str) -> Optional[str]:
+        """Get the id of the first table ina  section.
+        
+        Retrieve the first table_id (anchor id) of a <div class="table"> inside a <div class="section">
+        that contains an <a> anchor with the given section id.
+
+        Args:
+            dom (BeautifulSoup): The parsed XHTML DOM object.
+            section_id (str): The id of the section to search for the table_id.
+
+        Returns:
+            Optional[str]: The id of the first table anchor found, or None if not found.
+
+        """
+        # Find the anchor with the given id
+        anchor = dom.find("a", {"id": section_id})
+        if not anchor:
+            self.logger.warning(f"Section with id '{section_id}' not found.")
+            return None
+
+        # Find the parent section div
+        section_div = anchor.find_parent("div", class_="section")
+        if not section_div:
+            self.logger.warning(f"No parent <div class='section'> found for section id '{section_id}'.")
+            return None
+
+        # Find the first <div class="table"> inside the section
+        table_div = section_div.find("div", class_="table")
+        if not table_div:
+            self.logger.warning(f"No <div class='table'> found in section for section id '{section_id}'.")
+            return None
+
+        # Find the first anchor with an id inside the table div (the table id)
+        table_anchor = table_div.find("a", id=True)
+        if table_anchor and table_anchor.get("id"):
+            return table_anchor["id"]
+
+        self.logger.warning(f"No table id found in <div class='table'> for section id '{section_id}'.")
+        return None
+
     def _extract_row_data(self, row: Tag, table_nesting_level: int) -> Dict[str, Any]:
         """Extract data from a table row.
 

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -1,0 +1,158 @@
+"""Builder for combined DICOM IOD+modules specification models in dcmspec.
+
+This module provides the IODSpecBuilder class, which coordinates the construction of a 
+DICOM IOD model, combining the iod modeules and module attributes model.
+"""
+import logging
+import os
+
+from anytree import Node
+from dcmspec.spec_factory import SpecFactory
+from dcmspec.spec_model import SpecModel
+
+class IODSpecBuilder:
+    """Orchestrates the construction of a combined DICOM IOD+modules specification model.
+
+    The IODSpecBuilder uses a factory to build the main IOD model and, for each referenced module,
+    uses a (possibly different) factory to build and cache the module models. It then assembles a new
+    model with the IOD nodes and their referenced module nodes as children, and caches the combined model.
+    """
+
+    def __init__(self, iod_factory=None, module_factory=None, logger: logging.Logger = None):
+        """Initialize the IODSpecBuilder.
+
+        If no factory is provided, a default SpecFactory is used for both IOD and module models.
+
+        Args:
+            iod_factory (Optional[SpecFactory]): Factory for building the IOD model. If None, uses SpecFactory().
+            module_factory (Optional[SpecFactory]): Factory for building module models. If None, uses iod_factory.
+            logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
+
+        The builder is initialized with factories for the IOD and module models. By default, the same
+        factory is used for both, but a different factory can be provided for modules if needed.
+
+        """
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.iod_factory = iod_factory or SpecFactory(logger=self.logger)
+        self.module_factory = module_factory or self.iod_factory
+
+    def build_from_url(
+        self,
+        url: str,
+        cache_file_name: str,
+        table_id: str,
+        force_download: bool = False,
+        json_file_name: str = None,
+        **kwargs,
+    ):
+        """Build and cache a DICOM IOD specification model from a URL.
+
+        This method orchestrates the full workflow:
+        - Loads or downloads the IOD table and builds/caches the IOD model using the iod_factory.
+        - Finds all nodes in the IOD model with a "ref" attribute, indicating a referenced module.
+        - For each referenced module, loads or parses and caches the module model using the module_factory.
+        - Assembles a new combined model, where each IOD node has its referenced module's content node as a child.
+        - Uses the first module's metadata header and version for the combined model's metadata.
+        - Caches the combined model if a json_file_name is provided.
+
+        Args:
+            url (str): The URL to download the input file from.
+            cache_file_name (str): Filename of the cached input file.
+            table_id (str): The ID of the IOD table to parse.
+            force_download (bool): If True, always download the input file and generate the model even if cached.
+            json_file_name (str, optional): Filename to save the cached combined JSON model.
+            **kwargs: Additional arguments for model construction.
+
+        Returns:
+            SpecModel: The combined model with IOD and module content.
+
+        """
+        # Check if the combined model is already cached and valid
+        iod_json_file_path = None
+        if json_file_name:
+            iod_json_file_path = os.path.join(
+                self.iod_factory.config.get_param("cache_dir"), "model", json_file_name
+            )
+        if iod_json_file_path and os.path.exists(iod_json_file_path) and not force_download:
+            try:
+                return self.iod_factory.model_store.load(iod_json_file_path)
+            except Exception as e:
+                self.logger.warning(
+                    f"Failed to load combined model from cache {iod_json_file_path}: {e}"
+                )
+        # Only load/cache the DOM and build the model if not cached
+        dom = self.iod_factory.load_dom(
+            url=url,
+            cache_file_name=cache_file_name,
+            force_download=force_download,
+        )
+
+        # Build/load the IOD model from the DOM
+        iodmodules_model = self.iod_factory.build_model(
+            dom=dom,
+            table_id=table_id,
+            url=url,
+            json_file_name=json_file_name,
+            **kwargs,
+        )
+
+        # Find all nodes with a "ref" attribute in the main model
+        nodes_with_ref = [node for node in iodmodules_model.content.children if hasattr(node, "ref")]
+
+        # Collect module models for each referenced section
+        module_models = {}
+        for node in nodes_with_ref:
+            ref_value = getattr(node, "ref", None)
+            if not ref_value:
+                continue
+            section_id = f"sect_{ref_value}"
+            table_id = self.iod_factory.table_parser.get_table_id_from_section(dom, section_id)
+            if not table_id:
+                self.logger.warning(f"No table found for section id {section_id}")
+                continue
+
+            module_json_file_name = f"{table_id}.json"
+
+            module_model = self.module_factory.build_model(
+                dom=dom,
+                table_id=table_id,
+                url=url,
+                json_file_name=module_json_file_name,
+            )
+
+            module_models[ref_value] = module_model
+
+        # Fail if no module models were found.
+        if not module_models:
+            raise RuntimeError("No module models were found for the referenced modules in the IOD table.")
+
+        # Use the first module's metadata node for the combined model
+        first_module = next(iter(module_models.values()))
+        iod_metadata = first_module.metadata
+
+        # The content node will have as children the IOD model's nodes,
+        # and for each referenced module, its content's children will be attached directly under the iod node
+        iod_content = Node("content")
+        for iod_node in iodmodules_model.content.children:
+            ref_value = getattr(iod_node, "ref", None)
+            if ref_value and ref_value in module_models:
+                module_content = module_models[ref_value].content
+                # Attach each child of the module content directly under the iod node
+                for child in list(module_content.children):
+                    child.parent = iod_node
+            iod_node.parent = iod_content
+
+        # Create the combined model
+        iod_model = SpecModel(metadata=iod_metadata, content=iod_content)
+
+        # Cache the combined model if a json_file_name was provided
+        if json_file_name:
+            iod_json_file_path = os.path.join(
+                self.iod_factory.config.get_param("cache_dir"), "model", json_file_name
+            )
+            try:
+                self.iod_factory.model_store.save(iod_model, iod_json_file_path)
+            except Exception as e:
+                self.logger.warning(f"Failed to cache combined model to {iod_json_file_path}: {e}")
+
+        return iod_model

--- a/src/dcmspec/iod_spec_printer.py
+++ b/src/dcmspec/iod_spec_printer.py
@@ -1,0 +1,59 @@
+"""Printer class for DICOM IOD specification model in dcmspec.
+
+Provides the SpecPrinter class for printing DICOM IOD specification models (SpecModel)
+to standard output, either as a hierarchical tree or as a flat table, using rich formatting.
+"""
+from anytree import PreOrderIter
+from rich.table import Table, box
+
+from dcmspec.spec_printer import LEVEL_COLORS, SpecPrinter
+
+class IODSpecPrinter(SpecPrinter):
+    """Printer for DICOM IOD specification models with mixed node types.
+
+    Overrides print_table to display IOD Modules nodes as a one-cell title row (spanning all columns)
+    The table columns are those of the Module Attributes nodes.
+    """
+
+    def print_table(self, colorize: bool = False):
+        """Print the specification model as a flat table with module title rows.
+
+        Args:
+            colorize (bool): Whether to colorize the output by node depth.
+
+        """
+        table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
+
+        attr_headers = list(self.model.metadata.header)
+        for header in attr_headers:
+            table.add_column(header, width=20)
+
+        # Traverse the tree in PreOrder (as in the base class)
+        for node in PreOrderIter(self.model.content):
+            # skip the root node
+            if node.name == "content":
+                continue            # Print IOD module nodes as a title row (one cell, spanning all columns)
+            if hasattr(node, "module"):
+                iod_title = getattr(node, "module", getattr(node, "name", ""))
+                iod_usage = getattr(node, "usage", "")
+                iod_title_text = f"{iod_title} Module ({iod_usage})" if iod_usage else iod_title
+                # Set title style
+                row_style = (
+                    "magenta" if colorize else None
+                )
+                table.add_row(iod_title_text, *[""] * (len(attr_headers) - 1), style=row_style)
+            # Print module attribute nodes as regular rows
+            else:
+                row = [getattr(node, attr, "") for attr in self.model.metadata.column_to_attr.values()]
+                row_style = None
+                if colorize:
+                    row_style = (
+                        "yellow"
+                        if self.model._is_include(node)
+                        else "magenta"
+                        if self.model._is_title(node)
+                        else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
+                    )
+                table.add_row(*row, style=row_style)
+
+        self.console.print(table)

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -3,6 +3,7 @@
 Provides the SpecFactory class, which orchestrates downloading, parsing, and caching
 of DICOM specification tables from standard sources, producing structured SpecModel objects.
 """
+import logging
 import os
 from typing import Optional, Dict
 
@@ -22,7 +23,7 @@ class SpecFactory:
 
     Typical usage:
         factory = SpecFactory(...)
-        model = factory.from_url(...)
+        model = factory.create_model(...)
     """
 
     def __init__(
@@ -33,6 +34,7 @@ class SpecFactory:
         column_to_attr: Dict[int, str] = None,
         name_attr: str = None,
         config: Optional[Config] = None,
+        logger: Optional["logging.Logger"] = None,
     ):
         """Initialize the SpecFactory.
 
@@ -52,75 +54,110 @@ class SpecFactory:
             name_attr (str, optional): Attribute name to use for node names in the model.
                 If None, defaults to "elem_name".
             config (Optional[Config]): Configuration object. If None, a default Config is created.
+            logger (Optional[logging.Logger]): Logger instance to use.
+                If None, a default logger is created.
 
         Raises:
             TypeError: If config is not a Config instance or None.
 
         """
+        import logging
         if config is not None and not isinstance(config, Config):
             raise TypeError("config must be an instance of Config or None")
         self.config = config or Config()
 
-        self.input_handler = input_handler or XHTMLDocHandler(config=self.config)
-        self.model_store = model_store or JSONSpecStore()
-        self.table_parser = table_parser or DOMTableSpecParser()
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.input_handler = input_handler or XHTMLDocHandler(config=self.config, logger=self.logger)
+        self.model_store = model_store or JSONSpecStore(logger=self.logger)
+        self.table_parser = table_parser or DOMTableSpecParser(logger=self.logger)
         self.column_to_attr = column_to_attr or {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"}
         self.name_attr = name_attr or "elem_name"
 
-    def from_url(
-        self,
-        url: str,
-        cache_file_name: str,
-        table_id: Optional[str] = None,
-        force_download: bool = False,
-        json_file_name: Optional[str] = None,
-        **kwargs,
-    ) -> SpecModel:
-        """Create and cache a DICOM specification model from a URL.
-
-        Downloads (if needed) and parses an input file from a URL, creates the DICOMAttributeModel,
-        and caches the result as JSON. This method orchestrates the full workflow: downloading
-        (or using a cached file), parsing the DICOM specification table, constructing the model,
-        and saving it as a JSON file for future use.
+    def load_dom(self, url: str, cache_file_name: str, force_download: bool = False):
+        """Download, cache, and parse the specification file from a URL, returning the DOM.
 
         Args:
-            url: The URL to download the input file from.
-            cache_file_name: filename of the cached input file.
-            table_id: Optional table identifier for model parsing.
-            force_download: If True, always download the input file and generate the model even if cached.
-            json_file_name: Optional filename to save the cached JSON model.
-                Defaults to the base name of `cache_file_name` with a `.json` extension.
-            **kwargs: Additional arguments for model construction.
+            url (str): The URL to download the input file from.
+            cache_file_name (str): Filename of the cached input file.
+            force_download (bool): If True, always download the input file even if cached.
 
         Returns:
-            DICOMAttributeModel: The constructed model.
+            object: The parsed DOM (e.g., BeautifulSoup object).
 
         """
-        json_file_name = (
-            json_file_name or f"{os.path.splitext(cache_file_name)[0]}.json"
-        )
+        # This will download if needed and always parse/return the DOM
+        return self.input_handler.get_dom(cache_file_name=cache_file_name, url=url, force_download=force_download)
+
+
+    def build_model(
+        self,
+        dom,
+        table_id: Optional[str] = None,
+        url: Optional[str] = None,
+        json_file_name: Optional[str] = None,
+        include_depth: Optional[int] = None,
+        force_parse: bool = False,
+        **kwargs,
+    ) -> SpecModel:
+        """Build and cache a DICOM specification model from a parsed DOM.
+
+        Args:
+            dom: The parsed DOM object (e.g., BeautifulSoup).
+            table_id (Optional[str]): Table identifier for model parsing.
+            url (Optional[str]): The URL the DOM was fetched from (for metadata).
+            json_file_name (Optional[str]): Filename to save the cached JSON model.
+            include_depth (Optional[int]): The depth to which included tables should be parsed.
+            force_parse (bool): If True, always parse and (over)write the JSON cache file.
+            **kwargs: Additional arguments for model construction.
+
+        If `json_file_name` is not provided, the factory will attempt to use
+        `self.input_handler.cache_file_name` to generate a default JSON file name.
+        If neither is set, a ValueError is raised.
+
+        Returns:
+            SpecModel: The constructed model.
+
+        """
+        if json_file_name is None:
+            cache_file_name = getattr(self.input_handler, "cache_file_name", None)
+            if cache_file_name is None:
+                raise ValueError("input_handler.cache_file_name not set")
+            json_file_name = f"{os.path.splitext(cache_file_name)[0]}.json"
         json_file_path = os.path.join(self.config.get_param("cache_dir"), "model", json_file_name)
-        if os.path.exists(json_file_path) and not force_download:
+
+        if os.path.exists(json_file_path) and not force_parse:
             try:
                 model = self.model_store.load(json_file_path)
-                self.input_handler.logger.info(f"Loaded model from cache {json_file_path}")
-                model = SpecModel(
-                    metadata=model.metadata,
-                    content=model.content,
-                    **kwargs,
-                )
-                return model
+                self.logger.info(f"Loaded model from cache {json_file_path}")
+                # Check if include_depth matches the cached model's metadata
+                cached_depth = getattr(model.metadata, "include_depth", None)
+                if (
+                    (include_depth is not None and cached_depth is not None and int(cached_depth) != int(include_depth))
+                    or (include_depth is None and cached_depth is not None)
+                    or (include_depth is not None and cached_depth is None)
+                ):
+                    self.logger.info(
+                        (
+                            f"Cached model include_depth ({cached_depth}) "
+                            f"does not match requested ({include_depth}), reparsing."
+                        )
+                    )
+                    # Fallback to parsing: do not return cached model
+                else:
+                    model = SpecModel(
+                        metadata=model.metadata,
+                        content=model.content,
+                        **kwargs,
+                    )
+                    return model
             except Exception as e:
-                self.input_handler.logger.warning(f"Failed to load model from cache {json_file_path}: {e}")
-                # Fallback to input file
+                self.logger.warning(f"Failed to load model from cache {json_file_path}: {e}")
+                # Fallback to parsing
 
-        dom = self.input_handler.get_dom(cache_file_name=cache_file_name, url=url, force_download=force_download)
-        # TODO: make include_depth an argument
-        include_depth = 1
         metadata, content = self.table_parser.parse(
             dom,
             table_id=table_id,
-            include_depth=None,
+            include_depth=include_depth,
             column_to_attr=self.column_to_attr,
             name_attr=self.name_attr,
             **kwargs,
@@ -128,7 +165,9 @@ class SpecFactory:
         # Complete metadata
         metadata.url = url
         metadata.table_id = table_id
-        metadata.include_depth = include_depth
+        # Store include_depth as int if not None, else omit from metadata
+        if include_depth is not None:
+            metadata.include_depth = int(include_depth)
         metadata.column_to_attr = self.column_to_attr
         metadata.name_attr = self.name_attr
 
@@ -140,8 +179,50 @@ class SpecFactory:
 
         model.exclude_titles()
 
-        try:
-            self.model_store.save(model, json_file_path)
-        except Exception as e:
-            self.input_handler.logger.warning(f"Failed to cache model to {json_file_path}: {e}")
+        if json_file_name:
+            try:
+                self.model_store.save(model, json_file_path)
+            except Exception as e:
+                self.logger.warning(f"Failed to cache model to {json_file_path}: {e}")
         return model
+
+    def create_model(
+        self,
+        url: str,
+        cache_file_name: str,
+        table_id: Optional[str] = None,
+        force_parse: bool = False,
+        force_download: bool = False,
+        json_file_name: Optional[str] = None,
+        include_depth: Optional[int] = None,
+        **kwargs,
+    ) -> SpecModel:
+        """Integrated, one-step method to fetch, parse, and build a DICOM specification model from a URL.
+
+        Args:
+            url (str): The URL to download the input file from.
+            cache_file_name (str): Filename of the cached input file.
+            table_id (Optional[str]): Table identifier for model parsing.
+            force_parse (bool): If True, always parse the DOM and generate the JSON model, even if cached.
+            force_download (bool): If True, always download the input file and generate the model even if cached.
+            json_file_name (Optional[str]): Filename to save the cached JSON model.
+            include_depth (Optional[int]): The depth to which included tables should be parsed.
+            **kwargs: Additional arguments for model construction.
+
+        Returns:
+            SpecModel: The constructed model.
+
+        """
+        dom = self.load_dom(url=url, cache_file_name=cache_file_name, force_download=force_download)
+        return self.build_model(
+            dom=dom,
+            table_id=table_id,
+            url=url,
+            json_file_name=json_file_name,
+            include_depth=include_depth,
+            force_parse=force_parse or force_download, 
+            **kwargs,
+        )
+
+
+

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -4,11 +4,14 @@ Provides the XHTMLDocHandler class for downloading, caching, and parsing XHTML d
 from the DICOM standard, returning a BeautifulSoup DOM object.
 """
 
+import logging
 import os
 import re
 import requests
 from bs4 import BeautifulSoup
 from typing import Optional
+
+from dcmspec.config import Config
 from dcmspec.doc_handler import DocHandler
 
 
@@ -18,6 +21,11 @@ class XHTMLDocHandler(DocHandler):
     Provides methods to download, cache, and parse XHTML documents, returning a BeautifulSoup DOM object.
     Inherits configuration and logging from DocHandler.
     """
+
+    def __init__(self, config: Optional[Config] = None, logger: Optional[logging.Logger] = None):
+        """Initialize the XHTML document handler and set cache_file_name to None."""
+        super().__init__(config=config, logger=logger)
+        self.cache_file_name = None
 
     def get_dom(self, cache_file_name: str, url: Optional[str] = None, force_download: bool = False) -> BeautifulSoup:
         """Open and parse an XHTML file, downloading it if needed.
@@ -31,6 +39,9 @@ class XHTMLDocHandler(DocHandler):
             BeautifulSoup: Parsed DOM.
 
         """
+        # Set cache_file_name as an attribute for downstream use (e.g., in SpecFactory)
+        self.cache_file_name = cache_file_name
+
         cache_file_path = os.path.join(self.config.get_param("cache_dir"), "standard", cache_file_name)
         need_download = force_download or (not os.path.exists(cache_file_path))
         if need_download:

--- a/tests/fixtures_dom_tables.py
+++ b/tests/fixtures_dom_tables.py
@@ -304,3 +304,45 @@ def table_include_dom():
     </html>
     """
     return BeautifulSoup(xhtml, "lxml-xml")
+
+@pytest.fixture
+def section_dom():
+    """Return a BeautifulSoup DOM with a section and a table for get_table_id_from_section tests."""
+    xhtml = """
+    <div class="section">
+        <div class="titlepage">
+            <div>
+                <div>
+                    <h4 class="title">
+                        <a id="sect_C.7.1.1" shape="rect"></a>C.7.1.1&nbsp;Patient Module</h4>
+                </div>
+            </div>
+        </div>
+        <p>
+            <a class="xref" href="#table_C.7-1" title="Table&nbsp;C.7-1.&nbsp;Patient Module Attributes" shape="rect">Table&nbsp;C.7-1</a>
+        </p>
+        <div class="table">
+            <a id="table_C.7-1" shape="rect"></a>
+            <p class="title">
+                <strong>Table&nbsp;C.7-1.&nbsp;Patient Module Attributes</strong>
+            </p>
+            <div class="table-contents">
+                <table frame="box" rules="all">
+                    <thead>
+                        <tr>
+                            <th>Attribute Name</th>
+                            <th>Tag</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Patient's Name</td>
+                            <td>(0010,0010)</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    """
+    return BeautifulSoup(xhtml, "lxml-xml")

--- a/tests/test_spec_factory.py
+++ b/tests/test_spec_factory.py
@@ -13,11 +13,20 @@ class DummyInputHandler:
         """Initialize the dummy input handler."""
         self.called = False
         self.logger = logging.getLogger("DummyInputHandler")
+        self.cache_file_name = "file.xhtml"
 
     def get_dom(self, cache_file_name, url=None, force_download=False):
         """Simulate getting a DOM from a file or URL."""
         self.called = True
         return "DOM"
+
+class NoCacheFileNameInputHandler(DummyInputHandler):
+    """A dummy input handler without cache_file_name."""
+
+    def __init__(self):
+        """Initialize the no cache filename dummy input handler."""
+        super().__init__()
+        self.cache_file_name = None
 
 class DummyTableParser:
     """A dummy table parser that simulates parsing a DOM into metadata and content nodes."""
@@ -105,46 +114,72 @@ def test_init_type_error():
     with pytest.raises(TypeError):
         SpecFactory(config="not_a_config")
 
-def test_from_url_default_json_file_name(monkeypatch, patch_dirs):
-    """Test from_url uses default json_file_name if not provided."""
+def test_load_dom(monkeypatch):
+    """Test load_dom returns the DOM and calls input_handler.get_dom."""
+    ih = DummyInputHandler()
+    factory = SpecFactory(input_handler=ih)
+    dom = factory.load_dom(url="http://example.com", cache_file_name="file.xhtml", force_download=True)
+    assert dom == "DOM"
+    assert ih.called
+
+def test_build_model(monkeypatch, patch_dirs):
+    """Test build_model builds and saves the model, uses default json_file_name if not provided."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()
     factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
     monkeypatch.setattr("os.path.exists", lambda path: False)
-    cache_file_name = "file.xhtml"
-    # Do NOT provide json_file_name
-    factory.from_url(
-        url="http://example.com",
-        cache_file_name=cache_file_name,
+    dom = "DOM"
+    factory.build_model(
+        dom=dom,
         table_id="table1",
-        force_download=True,
+        url="http://example.com",
         # json_file_name is omitted
     )
     expected_path = str(patch_dirs / "cache" / "model" / "file.json")
     assert ms.saved[1] == expected_path
+    assert tp.called
 
-def test_from_url_loads_from_cache(monkeypatch, patch_dirs):
-    """Test from_url loads model from cache if present and not force_download."""
+def test_build_model_with_custom_json_file_name(monkeypatch, patch_dirs):
+    """Test build_model uses the provided custom json_file_name."""
     ms = DummyModelStore()
-    ms.load_should_fail = False
-    factory = SpecFactory(model_store=ms)
-    # Patch os.path.exists to always return True
-    monkeypatch.setattr("os.path.exists", lambda path: True)
-    # Patch config.get_param to return a dummy path
-    model = factory.from_url(
-        url="http://example.com",
-        cache_file_name="file.xhtml",
+    ih = DummyInputHandler()
+    tp = DummyTableParser()
+    factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    dom = "DOM"
+    custom_json_file_name = "custom_model.json"
+    factory.build_model(
+        dom=dom,
         table_id="table1",
-        force_download=False,
+        url="http://example.com",
+        json_file_name=custom_json_file_name,
+    )
+    expected_path = str(patch_dirs / "cache" / "model" / custom_json_file_name)
+    assert ms.saved[1] == expected_path
+    assert tp.called
+
+def test_build_model_loads_from_cache(monkeypatch, patch_dirs):
+    """Test build_model loads model from cache if present and not force_parse."""
+    ms = DummyModelStore()
+    ih = DummyInputHandler()
+    ms.load_should_fail = False
+    factory = SpecFactory(model_store=ms, input_handler=ih)
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    dom = "DOM"
+    model = factory.build_model(
+        dom=dom,
+        table_id="table1",
+        url="http://example.com",
         json_file_name="file.json",
+        force_parse=False,
     )
     assert isinstance(model, SpecModel)
     expected_path = str(patch_dirs / "cache" / "model" / "file.json")
     assert ms.loaded == expected_path
 
-def test_from_url_fallback_to_input(monkeypatch):
-    """Test from_url falls back to input handler and parser if cache load fails."""
+def test_build_model_fallback_to_parser(monkeypatch):
+    """Test build_model falls back to parser if cache load fails."""
     ms = DummyModelStore()
     ms.load_should_fail = True
     ih = DummyInputHandler()
@@ -153,18 +188,17 @@ def test_from_url_fallback_to_input(monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda path: True)
     # Patch model_store.save to do nothing
     monkeypatch.setattr(ms, "save", lambda model, path: None)
-    factory.from_url(
-        url="http://example.com",
-        cache_file_name="file.xhtml",
+    dom = "DOM"
+    factory.build_model(
+        dom=dom,
         table_id="table1",
-        force_download=False,
+        url="http://example.com",
         json_file_name="file.json",
     )
-    assert ih.called
     assert tp.called
 
-def test_from_url_force_download(monkeypatch):
-    """Test from_url uses input handler and parser if force_download is True."""
+def test_build_model_force_parse(monkeypatch):
+    """Test build_model parses and saves even if cache exists when force_parse is True."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()
@@ -172,22 +206,22 @@ def test_from_url_force_download(monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda path: True)
     # Patch model_store.save to do nothing
     monkeypatch.setattr(ms, "save", lambda model, path: None)
-    factory.from_url(
-        url="http://example.com",
-        cache_file_name="file.xhtml",
+    dom = "DOM"
+    factory.build_model(
+        dom=dom,
         table_id="table1",
-        force_download=True,
+        url="http://example.com",
         json_file_name="file.json",
+        force_parse=True,
     )
-    assert ih.called
     assert tp.called
 
 def raise_save_failure(*args, **kwargs):
     """Simulate a save failure by raising an IOError."""
     raise IOError("Simulated save failure")
 
-def test_from_url_save_failure(monkeypatch, caplog):
-    """Test from_url handles failure of model_store.save gracefully."""
+def test_build_model_save_failure(monkeypatch, caplog):
+    """Test build_model handles failure of model_store.save gracefully."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()
@@ -195,15 +229,127 @@ def test_from_url_save_failure(monkeypatch, caplog):
     monkeypatch.setattr("os.path.exists", lambda path: False)
     # Patch model_store.save to raise an exception
     monkeypatch.setattr(ms, "save", raise_save_failure)
+    dom = "DOM"
     with caplog.at_level("WARNING"):
-        factory.from_url(
-            url="http://example.com",
-            cache_file_name="file.xhtml",
+        factory.build_model(
+            dom=dom,
             table_id="table1",
-            force_download=True,
+            url="http://example.com",
             json_file_name="file.json",
         )
     log_output = caplog.text
     assert "Failed to cache model" in log_output
     assert "Simulated save failure" in log_output
 
+@pytest.fixture
+def fake_load_and_build(monkeypatch):
+    """Fixture providing fake load_dom and build_model methods for SpecFactory tests.
+
+    Returns:
+        tuple: (called, fake_load_dom, fake_build_model)
+            - called: dict to record the arguments with which the fakes are called.
+            - fake_load_dom: function to patch load_dom, records its arguments and returns a fake dom.
+            - fake_build_model: function to patch build_model, records its arguments and returns a fake model.
+
+    Usage:
+        called, fake_load_dom, fake_build_model = fake_load_and_build
+        monkeypatch.setattr(factory, "load_dom", fake_load_dom)
+        monkeypatch.setattr(factory, "build_model", fake_build_model)
+
+    """
+    called = {}
+
+    def fake_load_dom(url, cache_file_name, force_download):
+        called["load_dom"] = (url, cache_file_name, force_download)
+        return "FAKE_DOM"
+
+    def fake_build_model(dom, table_id, url, json_file_name, include_depth, force_parse, **kwargs):
+        called["build_model"] = (dom, table_id, url, json_file_name, include_depth, force_parse)
+        return "FAKE_MODEL"
+
+    return called, fake_load_dom, fake_build_model
+
+def test_build_model_raises_if_no_json_or_cache(monkeypatch):
+    """Test build_model raises ValueError if neither json_file_name nor cache_file_name is set."""
+    ms = DummyModelStore()
+    ih = NoCacheFileNameInputHandler()
+    tp = DummyTableParser()
+    factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
+    dom = "DOM"
+    with pytest.raises(ValueError, match="input_handler.cache_file_name not set"):
+        factory.build_model(
+            dom=dom,
+            table_id="table1",
+            url="http://example.com",
+            # json_file_name is omitted
+        )
+
+def test_create_model(monkeypatch, fake_load_and_build):
+    """Test create_model calls load_dom and build_model with correct arguments."""
+    ms = DummyModelStore()
+    ih = DummyInputHandler()
+    tp = DummyTableParser()
+    factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
+
+    called, fake_load_dom, fake_build_model = fake_load_and_build
+    monkeypatch.setattr(factory, "load_dom", fake_load_dom)
+    monkeypatch.setattr(factory, "build_model", fake_build_model)
+
+    result = factory.create_model(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table1",
+        force_download=True,
+        json_file_name="file.json",
+        include_depth=2,
+    )
+    assert result == "FAKE_MODEL"
+    assert called["load_dom"] == ("http://example.com", "file.xhtml", True)
+    assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, True)
+
+def test_create_model_force_download(monkeypatch, fake_load_and_build):
+    """Test create_model passes force_download to build_model if force_parse is not set."""
+    ms = DummyModelStore()
+    ih = DummyInputHandler()
+    tp = DummyTableParser()
+    factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
+
+    called, fake_load_dom, fake_build_model = fake_load_and_build
+    monkeypatch.setattr(factory, "load_dom", fake_load_dom)
+    monkeypatch.setattr(factory, "build_model", fake_build_model)
+
+    result = factory.create_model(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table1",
+        force_download=True,
+        json_file_name="file.json",
+        include_depth=2,
+    )
+    assert result == "FAKE_MODEL"
+    assert called["load_dom"] == ("http://example.com", "file.xhtml", True)
+    assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, True)
+
+def test_create_model_force_parse(monkeypatch, fake_load_and_build):
+    """Test create_model passes force_parse to build_model and it takes precedence over force_download."""
+    ms = DummyModelStore()
+    ih = DummyInputHandler()
+    tp = DummyTableParser()
+    factory = SpecFactory(model_store=ms, input_handler=ih, table_parser=tp)
+
+    called, fake_load_dom, fake_build_model = fake_load_and_build
+    monkeypatch.setattr(factory, "load_dom", fake_load_dom)
+    monkeypatch.setattr(factory, "build_model", fake_build_model)
+
+    result = factory.create_model(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table1",
+        force_download=False,
+        force_parse=True,
+        json_file_name="file.json",
+        include_depth=2,
+    )
+    assert result == "FAKE_MODEL"
+    assert called["load_dom"] == ("http://example.com", "file.xhtml", False)
+    assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, True)

--- a/tests/test_spec_factory.py
+++ b/tests/test_spec_factory.py
@@ -285,7 +285,7 @@ def test_build_model_raises_if_no_json_or_cache(monkeypatch):
         )
 
 def test_create_model(monkeypatch, fake_load_and_build):
-    """Test create_model calls load_dom and build_model with correct arguments."""
+    """Test create_model uses default force_download=False when not specified."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()
@@ -295,20 +295,21 @@ def test_create_model(monkeypatch, fake_load_and_build):
     monkeypatch.setattr(factory, "load_dom", fake_load_dom)
     monkeypatch.setattr(factory, "build_model", fake_build_model)
 
+    # Do not pass force_download, should default to False
     result = factory.create_model(
         url="http://example.com",
         cache_file_name="file.xhtml",
         table_id="table1",
-        force_download=True,
         json_file_name="file.json",
         include_depth=2,
     )
     assert result == "FAKE_MODEL"
-    assert called["load_dom"] == ("http://example.com", "file.xhtml", True)
-    assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, True)
+    # Assert that force_download is False by default
+    assert called["load_dom"] == ("http://example.com", "file.xhtml", False)
+    assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, False)
 
 def test_create_model_force_download(monkeypatch, fake_load_and_build):
-    """Test create_model passes force_download to build_model if force_parse is not set."""
+    """Test create_model uses force_download=True when specified."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()
@@ -331,7 +332,7 @@ def test_create_model_force_download(monkeypatch, fake_load_and_build):
     assert called["build_model"] == ("FAKE_DOM", "table1", "http://example.com", "file.json", 2, True)
 
 def test_create_model_force_parse(monkeypatch, fake_load_and_build):
-    """Test create_model passes force_parse to build_model and it takes precedence over force_download."""
+    """Test create_model uses force_parse=True and it takes precedence over force_download."""
     ms = DummyModelStore()
     ih = DummyInputHandler()
     tp = DummyTableParser()


### PR DESCRIPTION
- Add iod_spec_builder.py module
- Add get_table_id_from_section method in DOMTableSpecParser
- Add IODSpecPrinter subclass of SpecPrinter
- Refactor SpecFactory class to allow in-memory caching of DOM
- Update SpecFactory unit tests
- Update CLI apps for refactored SpecFactory

## Summary by Sourcery

Implement a new builder and printer for combined IOD+module specs, refactor SpecFactory into discrete loading, building, and creation steps with enhanced caching and logging, extend CLI apps with new parsing options, and add corresponding unit tests.

New Features:
- Add IODSpecBuilder class for assembling combined IOD and module specification models
- Introduce IODSpecPrinter subclass to render IOD models with module title rows
- Add get_table_id_from_section method to DOMTableSpecParser for resolving table IDs from section anchors
- Expose load_dom, build_model, and create_model methods in SpecFactory for granular control of fetching, parsing, and caching

Enhancements:
- Refactor SpecFactory to replace from_url with a split workflow (load_dom → build_model → create_model) and support include_depth, force_parse, and logging
- Update XHTMLDocHandler to record cache_file_name and allow in-memory caching
- Update CLI commands to use create_model instead of from_url and add --force-parse, --force-download, --include-depth, and --print-mode options

Tests:
- Expand SpecFactory unit tests to cover load_dom, build_model, create_model, error handling, and caching scenarios
- Add tests for DOMTableSpecParser.get_table_id_from_section covering successful lookup and various failure modes
- Introduce section_dom fixture for DOMTableSpecParser tests