### PR TITLE
Add MkDocs documentation setup

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,38 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Poetry
+        uses: pronovic/setup-poetry@v2
+        with:
+          version: "2.1.1"
+          cache-venv: "true"
+          cache-poetry: "true"
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Build docs
+        run: poetry run mkdocs build --clean
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist/
 .pytest_cache/
 .coverage
 
+# MkDocs
+site/
+
 # cache folder for standards inputs and model outputs
 cache/
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,0 +1,1 @@
+::: dcmspec.config.Config

--- a/docs/api/doc_handler.md
+++ b/docs/api/doc_handler.md
@@ -1,0 +1,1 @@
+::: dcmspec.doc_handler.DocHandler

--- a/docs/api/dom_table_spec_parser.md
+++ b/docs/api/dom_table_spec_parser.md
@@ -1,0 +1,1 @@
+::: dcmspec.dom_table_spec_parser.DOMTableSpecParser

--- a/docs/api/iod_spec_builder.md
+++ b/docs/api/iod_spec_builder.md
@@ -1,0 +1,1 @@
+::: dcmspec.iod_spec_builder.IODSpecBuilder

--- a/docs/api/iod_spec_printer.md
+++ b/docs/api/iod_spec_printer.md
@@ -1,0 +1,1 @@
+::: dcmspec.iod_spec_printer.IODSpecPrinter

--- a/docs/api/json_spec_store.md
+++ b/docs/api/json_spec_store.md
@@ -1,0 +1,1 @@
+::: dcmspec.json_spec_store.JSONSpecStore

--- a/docs/api/spec_factory.md
+++ b/docs/api/spec_factory.md
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+::: dcmspec.spec_factory.SpecFactory
+    options:
+        show_root_heading: true

--- a/docs/api/spec_model.md
+++ b/docs/api/spec_model.md
@@ -1,0 +1,1 @@
+::: dcmspec.spec_model.SpecModel

--- a/docs/api/spec_parser.md
+++ b/docs/api/spec_parser.md
@@ -1,0 +1,1 @@
+::: dcmspec.spec_parser.SpecParser

--- a/docs/api/spec_printer.md
+++ b/docs/api/spec_printer.md
@@ -1,0 +1,1 @@
+::: dcmspec.spec_printer.SpecPrinter

--- a/docs/api/spec_store.md
+++ b/docs/api/spec_store.md
@@ -1,0 +1,1 @@
+::: dcmspec.spec_store.SpecStore

--- a/docs/api/xhtml_doc_handler.md
+++ b/docs/api/xhtml_doc_handler.md
@@ -1,0 +1,1 @@
+::: dcmspec.xhtml_doc_handler.XHTMLDocHandler

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,0 +1,3 @@
+.doc {
+    font-size: .7rem;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+# DCMspec Documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: DCMspec Documentation
+nav:
+  - Home: index.md
+  - API Reference:
+      - Config: api/config.md
+      - SpecFactory: api/spec_factory.md
+      - IODSpecBuilder: api/iod_spec_builder.md
+      - SpecModel: api/spec_model.md
+      - SpecPrinter: api/spec_printer.md
+      - IODSpecPrinter: api/iod_spec_printer.md
+      - DocHandler: api/doc_handler.md
+      - XHTMLDocHandler: api/xhtml_doc_handler.md
+      - SpecParser: api/spec_parser.md
+      - DOMTableSpecParse: api/dom_table_spec_parser.md
+      - SpecStore: api/spec_store.md
+      - JSONSpecStore: api/json_spec_store.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            docstring_section_style: spacy
+            show_root_heading: yes
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: teal
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: cyan
+      accent: yellow
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+  features:
+    - navigation.expand
+
+extra_css:
+  - css/mkdocstrings.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ packages = [{include = "dcmspec", from = "src"}]
 pytest = "^8.3.5"
 pytest-cov = "^6.1.1"
 
+[tool.poetry.group.dev.dependencies]
+mkdocs = "^1.6.1"
+mkdocstrings = {extras = ["python"], version = "^0.29.1"}
+mkdocs-material = "^9.6.14"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- Add MkDocs , mkdocstrings and mkdocs-material as dev dependencies
- Add and configure mkdocs.yml for Material theme and API docs
- Create initial docs/ folder structure with API reference pages
- Add GitHub Actions workflow to build and deploy docs to GitHub Pages from gh_pages branch

## Summary by Sourcery

Add MkDocs-based documentation site with Material theme, integrate mkdocstrings for API docs, and automate build and deployment to GitHub Pages

Build:
- Add MkDocs, mkdocstrings, and mkdocs-material as development dependencies

CI:
- Add GitHub Actions workflow to build and deploy documentation to GitHub Pages

Documentation:
- Configure MkDocs with Material theme and API reference navigation
- Create initial docs/ folder with index, API reference pages, and custom CSS