### PR TITLE
Improve IODSpecBuilder class

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,8 @@
 site_name: DCMspec Documentation
+
+# NOTE: The API Reference section uses logical ordering (by functional area and workflow)
+# rather than alphabetical order. This is to help users find related concepts together
+# and to reflect the typical usage flow of the library.
 nav:
   - Home: index.md
   - API Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,18 +2,23 @@ site_name: DCMspec Documentation
 nav:
   - Home: index.md
   - API Reference:
-      - Config: api/config.md
-      - SpecFactory: api/spec_factory.md
-      - IODSpecBuilder: api/iod_spec_builder.md
-      - SpecModel: api/spec_model.md
-      - SpecPrinter: api/spec_printer.md
-      - IODSpecPrinter: api/iod_spec_printer.md
-      - DocHandler: api/doc_handler.md
-      - XHTMLDocHandler: api/xhtml_doc_handler.md
-      - SpecParser: api/spec_parser.md
-      - DOMTableSpecParse: api/dom_table_spec_parser.md
-      - SpecStore: api/spec_store.md
-      - JSONSpecStore: api/json_spec_store.md
+      - Core:
+          - SpecModel: api/spec_model.md
+          - SpecFactory: api/spec_factory.md
+          - IODSpecBuilder: api/iod_spec_builder.md
+      - Parse:
+          - SpecParser: api/spec_parser.md
+          - DOMTableSpecParser: api/dom_table_spec_parser.md
+      - Load/Store:
+          - DocHandler: api/doc_handler.md
+          - XHTMLDocHandler: api/xhtml_doc_handler.md
+          - SpecStore: api/spec_store.md
+          - JSONSpecStore: api/json_spec_store.md
+      - Print:
+          - SpecPrinter: api/spec_printer.md
+          - IODSpecPrinter: api/iod_spec_printer.md
+      - Utils:
+          - Config: api/config.md
 
 plugins:
   - search
@@ -24,7 +29,7 @@ plugins:
           options:
             docstring_style: google
             docstring_section_style: spacy
-            show_root_heading: yes
+            show_root_heading: no
             show_symbol_type_heading: true
             show_symbol_type_toc: true
 

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -1,7 +1,7 @@
-"""Builder for combined DICOM IOD+modules specification models in dcmspec.
+"""Builder for expanded DICOM IOD specification models in dcmspec.
 
 This module provides the IODSpecBuilder class, which coordinates the construction of a 
-DICOM IOD model, combining the iod modeules and module attributes model.
+DICOM IOD model, combining the IOD Modules and Module Attributes models.
 """
 import logging
 import os
@@ -11,14 +11,19 @@ from dcmspec.spec_factory import SpecFactory
 from dcmspec.spec_model import SpecModel
 
 class IODSpecBuilder:
-    """Orchestrates the construction of a combined DICOM IOD+modules specification model.
+    """Orchestrates the construction of a expanded DICOM IOD specification model.
 
-    The IODSpecBuilder uses a factory to build the main IOD model and, for each referenced module,
-    uses a (possibly different) factory to build and cache the module models. It then assembles a new
-    model with the IOD nodes and their referenced module nodes as children, and caches the combined model.
+    The IODSpecBuilder uses a factory to build the IOD Modules model and, for each referenced module,
+    uses a (possibly different) factory to build and cache the Module models. It then assembles a new
+    model with the IOD nodes and their referenced module nodes as children, and caches the expanded model.
     """
 
-    def __init__(self, iod_factory=None, module_factory=None, logger: logging.Logger = None):
+    def __init__(
+        self,
+        iod_factory: SpecFactory = None,
+        module_factory: SpecFactory = None,
+        logger: logging.Logger = None,
+    ):
         """Initialize the IODSpecBuilder.
 
         If no factory is provided, a default SpecFactory is used for both IOD and module models.
@@ -43,31 +48,79 @@ class IODSpecBuilder:
         table_id: str,
         force_download: bool = False,
         json_file_name: str = None,
-        **kwargs,
-    ):
+        **kwargs: object,
+    ) -> SpecModel:
         """Build and cache a DICOM IOD specification model from a URL.
 
         This method orchestrates the full workflow:
         - Loads or downloads the IOD table and builds/caches the IOD model using the iod_factory.
         - Finds all nodes in the IOD model with a "ref" attribute, indicating a referenced module.
         - For each referenced module, loads or parses and caches the module model using the module_factory.
-        - Assembles a new combined model, where each IOD node has its referenced module's content node as a child.
-        - Uses the first module's metadata header and version for the combined model's metadata.
-        - Caches the combined model if a json_file_name is provided.
+        - Assembles a new expanded model, where each IOD node has its referenced module's content node as a child.
+        - Uses the first module's metadata header and version for the expanded model's metadata.
+        - Caches the expanded model if a json_file_name is provided.
 
         Args:
             url (str): The URL to download the input file from.
             cache_file_name (str): Filename of the cached input file.
             table_id (str): The ID of the IOD table to parse.
             force_download (bool): If True, always download the input file and generate the model even if cached.
-            json_file_name (str, optional): Filename to save the cached combined JSON model.
+            json_file_name (str, optional): Filename to save the cached expanded JSON model.
             **kwargs: Additional arguments for model construction.
 
         Returns:
-            SpecModel: The combined model with IOD and module content.
+            SpecModel: The expanded model with IOD and module content.
 
         """
-        # Check if the combined model is already cached and valid
+        # Load from cache if the expanded IOD model is already present
+        cached_model = self._load_expanded_model_from_cache(json_file_name, force_download)
+        if cached_model is not None:
+            return cached_model
+
+        # Load the DOM from cache file or download and cache DOM in memory.
+        dom = self.iod_factory.load_dom(
+            url=url,
+            cache_file_name=cache_file_name,
+            force_download=force_download,
+        )
+
+        # Build the IOD Modules model from the DOM
+        iodmodules_model = self.iod_factory.build_model(
+            dom=dom,
+            table_id=table_id,
+            url=url,
+            json_file_name=json_file_name,
+            **kwargs,
+        )
+
+        # Find all nodes with a "ref" attribute in the IOD Modules model
+        nodes_with_ref = [node for node in iodmodules_model.content.children if hasattr(node, "ref")]
+
+        # Build or load module models for each referenced section
+        module_models = self._build_module_models(nodes_with_ref, dom, url)
+        # Fail if no module models were found.
+        if not module_models:
+            raise RuntimeError("No module models were found for the referenced modules in the IOD table.")
+
+        # Create the expanded model from the IOD modules and module models
+        iod_model = self._create_expanded_model(iodmodules_model, module_models)
+
+        # Cache the expanded model if a json_file_name was provided
+        if json_file_name:
+            iod_json_file_path = os.path.join(
+                self.iod_factory.config.get_param("cache_dir"), "model", json_file_name
+            )
+            try:
+                self.iod_factory.model_store.save(iod_model, iod_json_file_path)
+            except Exception as e:
+                self.logger.warning(f"Failed to cache expanded model to {iod_json_file_path}: {e}")
+        else:
+            self.logger.info("No json_file_name specified; IOD model not cached.")
+
+        return iod_model
+
+    def _load_expanded_model_from_cache(self, json_file_name: str, force_download: bool) -> SpecModel | None:
+        """Return the cached expanded IOD model if available and not force_download, else None."""
         iod_json_file_path = None
         if json_file_name:
             iod_json_file_path = os.path.join(
@@ -78,28 +131,12 @@ class IODSpecBuilder:
                 return self.iod_factory.model_store.load(iod_json_file_path)
             except Exception as e:
                 self.logger.warning(
-                    f"Failed to load combined model from cache {iod_json_file_path}: {e}"
+                    f"Failed to load expanded IOD model from cache {iod_json_file_path}: {e}"
                 )
-        # Only load/cache the DOM and build the model if not cached
-        dom = self.iod_factory.load_dom(
-            url=url,
-            cache_file_name=cache_file_name,
-            force_download=force_download,
-        )
+        return None
 
-        # Build/load the IOD model from the DOM
-        iodmodules_model = self.iod_factory.build_model(
-            dom=dom,
-            table_id=table_id,
-            url=url,
-            json_file_name=json_file_name,
-            **kwargs,
-        )
-
-        # Find all nodes with a "ref" attribute in the main model
-        nodes_with_ref = [node for node in iodmodules_model.content.children if hasattr(node, "ref")]
-
-        # Collect module models for each referenced section
+    def _build_module_models(self, nodes_with_ref, dom, url) -> dict:
+        """Build or load module models for each referenced section."""
         module_models = {}
         for node in nodes_with_ref:
             ref_value = getattr(node, "ref", None)
@@ -112,21 +149,33 @@ class IODSpecBuilder:
                 continue
 
             module_json_file_name = f"{table_id}.json"
-
-            module_model = self.module_factory.build_model(
-                dom=dom,
-                table_id=table_id,
-                url=url,
-                json_file_name=module_json_file_name,
+            module_json_file_path = os.path.join(
+                self.module_factory.config.get_param("cache_dir"), "model", module_json_file_name
             )
-
+            if os.path.exists(module_json_file_path):
+                try:
+                    module_model = self.module_factory.model_store.load(module_json_file_path)
+                except Exception as e:
+                    self.logger.warning(f"Failed to load module model from cache {module_json_file_path}: {e}")
+                    module_model = self.module_factory.build_model(
+                        dom=dom,
+                        table_id=table_id,
+                        url=url,
+                        json_file_name=module_json_file_name,
+                    )
+            else:
+                module_model = self.module_factory.build_model(
+                    dom=dom,
+                    table_id=table_id,
+                    url=url,
+                    json_file_name=module_json_file_name,
+                )
             module_models[ref_value] = module_model
-
-        # Fail if no module models were found.
-        if not module_models:
-            raise RuntimeError("No module models were found for the referenced modules in the IOD table.")
-
-        # Use the first module's metadata node for the combined model
+        return module_models
+    
+    def _create_expanded_model(self, iodmodules_model: SpecModel, module_models: dict) -> SpecModel:
+        """Create the expanded model by attaching Module nodes content to IOD nodes."""
+        # Use the first module's metadata node for the expanded model
         first_module = next(iter(module_models.values()))
         iod_metadata = first_module.metadata
 
@@ -137,24 +186,9 @@ class IODSpecBuilder:
             ref_value = getattr(iod_node, "ref", None)
             if ref_value and ref_value in module_models:
                 module_content = module_models[ref_value].content
-                # Attach each child of the module content directly under the iod node
                 for child in list(module_content.children):
                     child.parent = iod_node
             iod_node.parent = iod_content
 
-        # Create the combined model
-        iod_model = SpecModel(metadata=iod_metadata, content=iod_content)
-
-        # Cache the combined model if a json_file_name was provided
-        if json_file_name:
-            iod_json_file_path = os.path.join(
-                self.iod_factory.config.get_param("cache_dir"), "model", json_file_name
-            )
-            try:
-                self.iod_factory.model_store.save(iod_model, iod_json_file_path)
-            except Exception as e:
-                self.logger.warning(f"Failed to cache combined model to {iod_json_file_path}: {e}")
-        else:
-            self.logger.info("No json_file_name specified; IOD model not cached.")
-
-        return iod_model
+        # Create and return the expanded model
+        return SpecModel(metadata=iod_metadata, content=iod_content)

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -143,12 +143,12 @@ class IODSpecBuilder:
             if not ref_value:
                 continue
             section_id = f"sect_{ref_value}"
-            table_id = self.iod_factory.table_parser.get_table_id_from_section(dom, section_id)
-            if not table_id:
+            module_table_id = self.iod_factory.table_parser.get_table_id_from_section(dom, section_id)
+            if not module_table_id:
                 self.logger.warning(f"No table found for section id {section_id}")
                 continue
 
-            module_json_file_name = f"{table_id}.json"
+            module_json_file_name = f"{module_table_id}.json"
             module_json_file_path = os.path.join(
                 self.module_factory.config.get_param("cache_dir"), "model", module_json_file_name
             )
@@ -159,14 +159,14 @@ class IODSpecBuilder:
                     self.logger.warning(f"Failed to load module model from cache {module_json_file_path}: {e}")
                     module_model = self.module_factory.build_model(
                         dom=dom,
-                        table_id=table_id,
+                        table_id=module_table_id,
                         url=url,
                         json_file_name=module_json_file_name,
                     )
             else:
                 module_model = self.module_factory.build_model(
                     dom=dom,
-                    table_id=table_id,
+                    table_id=module_table_id,
                     url=url,
                     json_file_name=module_json_file_name,
                 )

--- a/tests/test_iod_spec_builder.py
+++ b/tests/test_iod_spec_builder.py
@@ -282,9 +282,6 @@ def test_iod_spec_builder_load_cache_failure(monkeypatch, tmp_path, caplog):
     # The model should still be returned (built, not loaded)
     assert isinstance(model, SpecModel)
     # The warnings for both expanded IOD and Module model should be logged
-    assert (
-        "Failed to load expanded IOD model from cache" in caplog.text
-        or "Failed to load expanded model from cache" in caplog.text
-    )
+    assert "Failed to load expanded IOD model from cache" in caplog.text
     assert "Failed to load module model from cache" in caplog.text
     assert "Simulated load failure" in caplog.text


### PR DESCRIPTION
- Add loading of referenced modules from cache
- Split build_from_url in smaller methods
- Fix missing type hints
- Use expland vs combine for clarity
- Update unit tests

## Summary by Sourcery

Refactor IODSpecBuilder to improve module caching and clarity, split its main workflow into helper methods, add missing type hints, rename “combined” to “expanded” throughout, update API navigation in documentation, and adjust unit tests to cover the new caching and loading behavior.

Enhancements:
- Extract cache loading, module building, and model creation into separate private methods
- Implement loading of referenced module models from cache with fallback to rebuild
- Add return and parameter type hints to IODSpecBuilder methods
- Rename "combined" terminology to "expanded" in code and documentation
- Reorganize mkdocs navigation into logical API categories and adjust doc generation settings

Documentation:
- Restructure mkdocs.yml to group API reference by Core, Parse, Load/Store, Print, and Utils
- Disable root heading in autodoc plugin settings

Tests:
- Update unit tests to reference expanded model behavior and include cache_dir and model_store stubs
- Enhance tests to verify caching, loading failures, and warning logging for both IOD and module models