### PR TITLE
Update type hints and docstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_name: DCMspec Documentation
 # and to reflect the typical usage flow of the library.
 nav:
   - Home: index.md
+  - Installation: installation.md
   - API Reference:
       - Core:
           - SpecModel: api/spec_model.md
@@ -37,7 +38,7 @@ plugins:
           options:
             docstring_style: google
             docstring_section_style: spacy
-            show_root_heading: yes
+            show_root_heading: true
             show_symbol_type_heading: true
             show_symbol_type_toc: true
 

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -49,7 +49,6 @@ class DOMTableSpecParser(SpecParser):
             table_id (str): The ID of the table to parse.
             column_to_attr (Dict[int, str]): Mapping from column indices to attribute names for tree nodes.
             name_attr (str): The attribute name to use for building node names.
-            table_nesting_level (int, optional): The nesting level of the table (used for recursion). Defaults to 0.
             include_depth (Optional[int], optional): The depth to which included tables should be parsed. 
                 None means unlimited.
 

--- a/src/dcmspec/service_attribute_model.py
+++ b/src/dcmspec/service_attribute_model.py
@@ -6,7 +6,9 @@ enables selection and filtering of attributes and columns based on DIMSE service
 allowing extraction of service- and role-specific attribute sets from a combined table.
 """
 
-from anytree import PreOrderIter
+import logging
+from typing import Optional, Sequence
+from anytree import Node, PreOrderIter
 
 from dcmspec.spec_model import SpecModel
 
@@ -21,10 +23,10 @@ class ServiceAttributeModel(SpecModel):
 
     def __init__(
         self,
-        metadata: object,
-        content: object,
+        metadata: Node,
+        content: Node,
         dimse_mapping: dict,
-        logger: object = None
+        logger: Optional[logging.Logger] = None
     ) -> None:
         """Initialize the ServiceAttributeModel.
 
@@ -126,7 +128,7 @@ class ServiceAttributeModel(SpecModel):
         self._update_metadata_for_dimse(dimse_attributes, all_attributes)
 
 
-    def _filter_node_attributes(self, dimse_attributes: list, all_attributes: list) -> None:
+    def _filter_node_attributes(self, dimse_attributes: Sequence[str], all_attributes: Sequence[str]) -> None:
         """Remove DIMSE attributes that are not belonging to the selected DIMSE."""
         for node in PreOrderIter(self.content):
             for attr in list(node.__dict__.keys()):
@@ -134,7 +136,7 @@ class ServiceAttributeModel(SpecModel):
                 if attr in all_attributes and attr not in dimse_attributes:
                     delattr(node, attr)
 
-    def _update_metadata_for_dimse(self, dimse_attributes: list, all_attributes: list) -> None:
+    def _update_metadata_for_dimse(self, dimse_attributes: Sequence[str], all_attributes: Sequence[str]) -> None:
         if hasattr(self.metadata, "header") and hasattr(self.metadata, "column_to_attr"):
             # Build new header and mapping, keeping original indices for column_to_attr
             new_header = []

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -5,7 +5,9 @@ of DICOM specification tables from standard sources, producing structured SpecMo
 """
 import logging
 import os
-from typing import Optional, Dict
+from typing import Any, Optional, Dict
+
+from bs4 import BeautifulSoup
 
 from dcmspec.config import Config
 from dcmspec.spec_model import SpecModel
@@ -32,13 +34,13 @@ class SpecFactory:
     def __init__(
         self,
         input_handler: Optional[DocHandler] = None,
-        model_class: Optional[SpecModel] = None,
+        model_class: Optional[type] = None,
         model_store: Optional[SpecStore] = None,
         table_parser: Optional[SpecParser] = None,
-        column_to_attr: Dict[int, str] = None,
-        name_attr: str = None,
+        column_to_attr: Optional[Dict[int, str]] = None,
+        name_attr: Optional[str] = None,
         config: Optional[Config] = None,
-        logger: Optional["logging.Logger"] = None,
+        logger: Optional[logging.Logger] = None,
     ):
         """Initialize the SpecFactory.
 
@@ -47,17 +49,17 @@ class SpecFactory:
         tag, type, and description.
 
         Args:
-            model_class (Optional[type]): The class to instantiate for the model (must be a subclass of SpecModel).
-                If None, defaults to SpecModel.
             input_handler (Optional[DocHandler]): Handler for downloading and parsing input files.
                 If None, a default XHTMLDocHandler is used.
+            model_class (Optional[type]): The class to instantiate for the model (must be a subclass of SpecModel).
+                If None, defaults to SpecModel.
             model_store (Optional[SpecStore]): Store for loading and saving models.
                 If None, a default JSONSpecStore is used.
             table_parser (Optional[SpecParser]): Parser for extracting tables from documents.
                 If None, a default DOMTableSpecParser is used.
-            column_to_attr (Dict[int, str], optional): Mapping from column indices to names of attributes
+            column_to_attr (Optional[Dict[int, str]]): Mapping from column indices to names of attributes
                 of model nodes. If None, a default mapping is used.
-            name_attr (str, optional): Attribute name to use for node names in the model.
+            name_attr (Optional[str]): Attribute name to use for node names in the model.
                 If None, defaults to "elem_name".
             config (Optional[Config]): Configuration object. If None, a default Config is created.
             logger (Optional[logging.Logger]): Logger instance to use.
@@ -80,7 +82,7 @@ class SpecFactory:
         self.column_to_attr = column_to_attr or {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"}
         self.name_attr = name_attr or "elem_name"
 
-    def load_dom(self, url: str, cache_file_name: str, force_download: bool = False):
+    def load_dom(self, url: str, cache_file_name: str, force_download: bool = False) -> BeautifulSoup:
         """Download, cache, and parse the specification file from a URL, returning the DOM.
 
         Args:
@@ -89,7 +91,7 @@ class SpecFactory:
             force_download (bool): If True, always download the input file even if cached.
 
         Returns:
-            object: The parsed DOM (e.g., BeautifulSoup object).
+            BeautifulSoup: The parsed DOM.
 
         """
         # This will download if needed and always parse/return the DOM
@@ -98,27 +100,28 @@ class SpecFactory:
 
     def build_model(
         self,
-        dom,
+        dom: BeautifulSoup,
         table_id: Optional[str] = None,
         url: Optional[str] = None,
         json_file_name: Optional[str] = None,
         include_depth: Optional[int] = None,
         force_parse: bool = False,
-        model_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ) -> SpecModel:
         """Build and cache a DICOM specification model from a parsed DOM.
 
         Args:
-            dom: The parsed DOM object (e.g., BeautifulSoup).
+            dom (BeautifulSoup): The parsed DOM object (e.g., BeautifulSoup).
             table_id (Optional[str]): Table identifier for model parsing.
             url (Optional[str]): The URL the DOM was fetched from (for metadata).
             json_file_name (Optional[str]): Filename to save the cached JSON model.
             include_depth (Optional[int]): The depth to which included tables should be parsed.
             force_parse (bool): If True, always parse and (over)write the JSON cache file.
-            model_kwargs (Optional[dict]): Additional keyword arguments for model construction.
+            model_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments for model construction.
                 Use this to supply extra parameters required by custom SpecModel subclasses.
                 For example, if your model class is `MyModel(metadata, content, foo, bar)`, pass
                 `model_kwargs={"foo": foo_value, "bar": bar_value}`.
+
         If `json_file_name` is not provided, the factory will attempt to use
         `self.input_handler.cache_file_name` to generate a default JSON file name.
         If neither is set, a ValueError is raised.
@@ -205,7 +208,7 @@ class SpecFactory:
         force_download: bool = False,
         json_file_name: Optional[str] = None,
         include_depth: Optional[int] = None,
-        model_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ) -> SpecModel:
         """Integrated, one-step method to fetch, parse, and build a DICOM specification model from a URL.
 
@@ -217,10 +220,11 @@ class SpecFactory:
             force_download (bool): If True, always download the input file and generate the model even if cached.
             json_file_name (Optional[str]): Filename to save the cached JSON model.
             include_depth (Optional[int]): The depth to which included tables should be parsed.
-            model_kwargs (Optional[dict]): Additional keyword arguments for model construction.
+            model_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments for model construction.
                 Use this to supply extra parameters required by custom SpecModel subclasses.
                 For example, if your model class is `MyModel(metadata, content, foo, bar)`, pass
                 `model_kwargs={"foo": foo_value, "bar": bar_value}`.
+
                 
         Returns:
             SpecModel: The constructed model.

--- a/src/dcmspec/spec_model.py
+++ b/src/dcmspec/spec_model.py
@@ -43,7 +43,7 @@ class SpecModel:
         self.metadata = metadata
         self.content = content
 
-    def exclude_titles(self):
+    def exclude_titles(self) -> None:
         """Remove nodes corresponding to title rows from the content tree.
 
         Title rows are typically found in some DICOM tables and represent section headers
@@ -63,7 +63,7 @@ class SpecModel:
                 self.logger.debug(f"Removing title node: {node.name}")
                 node.parent = None
 
-    def filter_required(self, type_attr_name: str, keep: Optional[str] = None, remove: Optional[str] = None):
+    def filter_required(self, type_attr_name: str, keep: Optional[str] = None, remove: Optional[str] = None) -> None:
         """Remove nodes that are considered optional according to DICOM requirements.
 
         This method traverses the content tree and removes nodes whose requirement
@@ -108,10 +108,14 @@ class SpecModel:
                     for descendant in node.descendants:
                         descendant.parent = None
 
-    def _create_default_logger(self):
+    def _create_default_logger(self) -> logging.Logger:
         """Create a default logger for the class.
 
         Configures a logger with a console handler and a specific format.
+
+        Returns:
+            logging.Logger: The configured logger instance.
+
         """
         logger = logging.getLogger("DICOMAttributeModel")
         logger.setLevel(logging.DEBUG)

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.table import Table, box
 from rich.text import Text
 from anytree import RenderTree, PreOrderIter
-from typing import Optional
+from typing import Optional, List, Union
 import logging
 
 LEVEL_COLORS = [
@@ -19,7 +19,6 @@ LEVEL_COLORS = [
     "rgb(0,0,255)",  # Node depth 5, Table Level 4: Blue
 ]
 
-
 class SpecPrinter:
     """Printer for DICOM specification models.
 
@@ -27,11 +26,11 @@ class SpecPrinter:
     using rich formatting for console output. Supports colorized output and customizable logging.
     """
 
-    def __init__(self, model, logger: Optional[logging.Logger] = None):
+    def __init__(self, model: object, logger: Optional[logging.Logger] = None) -> None:
         """Initialize the input handler with an optional logger.
 
         Args:
-            model: An instance of SpecModel.
+            model (object): An instance of SpecModel.
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
 
         """
@@ -41,12 +40,13 @@ class SpecPrinter:
 
         self.model = model
         self.console = Console(highlight=False)
+
     def print_tree(
         self,
-        attr_names: Optional[list[str]] = None,
-        attr_widths: Optional[list[int]] = None,
+        attr_names: Optional[Union[str, List[str]]] = None,
+        attr_widths: Optional[List[int]] = None,
         colorize: bool = False,
-    ):
+    ) -> None:
         """Print the specification model as a hierarchical tree to the console.
 
         Args:
@@ -61,6 +61,9 @@ class SpecPrinter:
         Example:
             # This will nicely align the tag, type, and name values in the tree output:
             printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64])
+
+        Returns:
+            None
 
         """
         for pre, fill, node in RenderTree(self.model.content):
@@ -82,9 +85,7 @@ class SpecPrinter:
                 node_text = Text(attr_text, style=style)
             self.console.print(pre_text + node_text)
 
-
-
-    def print_table(self, colorize: bool = False):
+    def print_table(self, colorize: bool = False) -> None:
         """Print the specification model as a flat table to the console.
 
         Traverses the content tree and prints each node's attributes in a flat table,
@@ -93,6 +94,9 @@ class SpecPrinter:
         Args:
             colorize (bool): Whether to colorize the output by node depth.
 
+        Returns:
+            None
+            
         """
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
@@ -118,4 +122,3 @@ class SpecPrinter:
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
-


### PR DESCRIPTION
- Fix mkdocs warnings

## Summary by Sourcery

Improve code clarity by adding comprehensive type hints and refining docstrings across core modules, remove an unused parser argument, and update mkdocs configuration to fix documentation warnings.

Enhancements:
- Add type annotations to core modules (ServiceAttributeModel, SpecFactory, SpecPrinter, SpecModel) including parameters and return types
- Refine docstrings with explicit parameter and return sections throughout the codebase
- Remove the unused `table_nesting_level` argument from DomTableParser

Documentation:
- Update mkdocs config: add "Installation" page to navigation and adjust boolean syntax to resolve warnings