### PR TITLE
Add model merging functionality

### DIFF
--- a/docs/api/spec_merger.md
+++ b/docs/api/spec_merger.md
@@ -1,0 +1,1 @@
+::: dcmspec.spec_merger.SpecMerger

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - API Reference:
       - Core:
           - SpecModel: api/spec_model.md
+          - SpecMerger: api/spec_merger.md
           - ServiceAttributeModel: api/service_attribute_model.md
           - Service Attribute Defaults: api/service_attribute_defaults.md
           - SpecFactory: api/spec_factory.md

--- a/src/dcmspec/cli/modattributes.py
+++ b/src/dcmspec/cli/modattributes.py
@@ -1,14 +1,62 @@
 import os
 import argparse
+import logging
 from dcmspec.config import Config
 
 from dcmspec.spec_factory import SpecFactory
+from dcmspec.spec_merger import SpecMerger
 from dcmspec.spec_printer import SpecPrinter
 
 
-def main():
+def create_module_model(config, table_id, force_parse, force_download, include_depth, logger=None):
     url = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
+    cache_file_name = "Part3.xhtml"
+    model_file_name = f"Part3_{table_id}.json"
+    factory = SpecFactory(
+        column_to_attr={0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"}, 
+        name_attr="elem_name",
+        config=config,
+        logger=logger,
+    )
+    if logger:
+        logger.debug(f"Creating module model: cache_file_name={cache_file_name}, model_file_name={model_file_name}")
+    return factory.create_model(
+        url=url,
+        cache_file_name=cache_file_name,
+        json_file_name=model_file_name,
+        table_id=table_id,
+        force_parse=force_parse,
+        force_download=force_download,
+        include_depth=include_depth,
+    )
 
+def create_part6_model(config, logger=None):
+    url = "https://dicom.nema.org/medical/dicom/current/output/chtml/part06/chapter_6.html"
+    cache_file_name = "DataElements.xhtml"
+    json_cache_path = "DataElements.json"
+    table_id = "table_6-1"
+    factory = SpecFactory(
+        column_to_attr={
+            0: "elem_tag",
+            1: "elem_name",
+            2: "elem_keyword",
+            3: "elem_vr",
+            4: "elem_vm",
+            5: "elem_status"
+            }, 
+        config=config,
+        logger=logger,
+    )
+    logger.debug(f"Creating part6 model: cache_file_name={cache_file_name}, json_cache_path={json_cache_path}")
+    return factory.create_model(
+        url=url,
+        cache_file_name=cache_file_name,
+        table_id=table_id,
+        force_download=False,
+        json_file_name=json_cache_path,
+    )
+
+def main():
     # Parse command-line arguments
     parser = argparse.ArgumentParser()
     parser.add_argument("table", help="Table ID")
@@ -22,57 +70,114 @@ def main():
     parser.add_argument(
         "--force-parse",
         action="store_true",
-        help="Force reparsing of the DOM and regeneration of the JSON model, even if the JSON cache exists"
-    )    
+        help="Force reparsing of the DOM and regeneration of the JSON model, even if the JSON cache exists."
+    )
     parser.add_argument(
         "--force-download",
         action="store_true",
-        help="Force download of the input file and regeneration of the model, even if cached"
+        help=(
+            "Force download of the input file and regeneration of the model, even if cached. "
+            "Implies --force-parse (the file will also be re-parsed)."
+        )
     )
     parser.add_argument(
-        "--print-mode",
+        "--print-mode", 
         choices=["table", "tree", "none"],
         default="table",
         help="Print as 'table' (default), 'tree', or 'none' to skip printing"
     )
-
+    parser.add_argument(
+        "--add-part6",
+        nargs="+",
+        choices=["VR", "VM", "Keyword", "Status"],  
+        help="Specification to merge from Part 6 (e.g. --add-part6 VR VM)"
+    )
+    parser.add_argument(
+        "--force-update",
+        action="store_true",
+        help="Force update of the specifications merged from part 6, even if cached"
+        )
+    parser.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="Enable debug logging to the console (overrides --verbose)"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose (info-level) logging to the console"
+    )
+    
     args = parser.parse_args()
 
-    cache_file_name = "Part3.xhtml"
-    model_file_name = f"Part3_{args.table}.json"
-    table_id = args.table 
+    # Set up logger
+    logger = logging.getLogger("modattributes")
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    if not logger.hasHandlers():
+        logger.addHandler(handler)
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+        handler.setLevel(logging.DEBUG)
+    elif args.verbose:
+        logger.setLevel(logging.INFO)
+        handler.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
+        handler.setLevel(logging.WARNING)
 
     # Determine config file location
     config_file = args.config or os.getenv("DCMSPEC_CONFIG", None)
+    config = Config(app_name="modattributes", config_file=config_file)
 
-    # Initialize configuration
-    config = Config(app_name="dcmspec", config_file=config_file)
+    logger.debug(f"Config file: {config_file}")
+    logger.debug(f"Cache dir: {config.get_param('cache_dir')}")
+    logger.debug(f"Table ID: {args.table}")
 
-    # Create the factory
-    factory = SpecFactory(
-        column_to_attr={0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"}, 
-        name_attr="elem_name",
+    # Create the module model
+    module_model = create_module_model(
         config=config,
-    )
-
-    # Download, parse, and cache the model
-    model = factory.create_model(
-        url=url,
-        cache_file_name=cache_file_name,
-        json_file_name=model_file_name,
-        table_id=table_id,
+        table_id=args.table,
         force_parse=args.force_parse,
         force_download=args.force_download,
         include_depth=args.include_depth,
+        logger=logger,
     )
 
+    # Optionally enrich with Part 6
+    part6_attr_map = {
+        "VR": "elem_vr",
+        "VM": "elem_vm",
+        "Keyword": "elem_keyword",
+        "Status": "elem_status",
+    }
+    merge_attrs = [part6_attr_map[x] for x in (args.add_part6 or [])]
+
+    if merge_attrs:
+        model_file_name = f"Part3_{args.table}_enriched.json"
+        part6_model = create_part6_model(config, logger=logger)
+        logger.debug("Merging module model with part6 model.")
+        merger = SpecMerger(config=config, logger=logger)
+        model = merger.merge_node(
+            module_model,
+            part6_model,
+            match_by= "attribute",
+            attribute_name="elem_tag",
+            merge_attrs=merge_attrs,
+            json_file_name=model_file_name,
+            force_update=args.force_update or args.force_download or args.force_parse,
+        )
+    else:
+        model = module_model
+
+    logger.debug("Model ready for printing/output")
     printer = SpecPrinter(model)
     if args.print_mode == "tree":
         printer.print_tree(colorize=True)
     elif args.print_mode == "table":
         printer.print_table(colorize=True)
     # else: do not print anything if print_mode == "none"
-
 
 if __name__ == "__main__":
     main()

--- a/src/dcmspec/cli/modattributes.py
+++ b/src/dcmspec/cli/modattributes.py
@@ -33,7 +33,7 @@ def create_module_model(config, table_id, force_parse, force_download, include_d
 def create_part6_model(config, logger=None):
     url = "https://dicom.nema.org/medical/dicom/current/output/chtml/part06/chapter_6.html"
     cache_file_name = "DataElements.xhtml"
-    json_cache_path = "DataElements.json"
+    json_file_name = "DataElements.json"
     table_id = "table_6-1"
     factory = SpecFactory(
         column_to_attr={
@@ -47,13 +47,14 @@ def create_part6_model(config, logger=None):
         config=config,
         logger=logger,
     )
-    logger.debug(f"Creating part6 model: cache_file_name={cache_file_name}, json_cache_path={json_cache_path}")
+    if logger:
+        logger.debug(f"Creating part6 model: cache_file_name={cache_file_name}, json_cache_path={json_file_name}")
     return factory.create_model(
         url=url,
         cache_file_name=cache_file_name,
         table_id=table_id,
         force_download=False,
-        json_file_name=json_cache_path,
+        json_file_name=json_file_name,
     )
 
 def main():

--- a/src/dcmspec/spec_merger.py
+++ b/src/dcmspec/spec_merger.py
@@ -1,0 +1,330 @@
+"""Merger for combining DICOM specification models in dcmspec.
+
+This module provides the SpecMerger class, which provides a method to merge
+DICOM specifications from multiple models.
+"""
+import logging
+import os
+
+from dcmspec.config import Config
+from dcmspec.json_spec_store import JSONSpecStore
+from dcmspec.spec_factory import SpecStore
+from dcmspec.spec_model import SpecModel
+
+class SpecMerger:
+    """Merges multiple DICOM specification models.
+
+    The SpecMerger class provides methods to combine and enrich DICOM SpecModel objects,
+    supporting both path-based and node-based merging strategies. This is useful for
+    workflows where you need to sequentially merge two or more models, such as enriching
+    PS3.3 module attributes models with definitions from the PS3.6 data elements dictionary,
+    or combining a PS3.3 specification with a PS3.4 SOP class and then enriching with an 
+    IHE profile specification.
+    """
+
+    def __init__(self, config: Config = None, model_store: SpecStore = None, logger: logging.Logger = None):
+        """Initialize the SpecMerger.
+
+        Sets up the logger for the merger. If no logger is provided, a default logger is created.
+        If no model_store is provided, defaults to JSONSpecStore.
+
+        Args:
+            config (Optional[Config]): Configuration object. If None, a default Config is created.
+            model_store (Optional[SpecStore]): Store for loading and saving models. Defaults to JSONSpecStore.
+            logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
+
+        """
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.config = config or Config()
+        self.model_store = model_store or JSONSpecStore(logger=self.logger)
+
+    def merge_node(
+        self,
+        model1: SpecModel,
+        model2: SpecModel,
+        match_by: str = "name",
+        attribute_name: str = None,
+        merge_attrs: list[str] = None,
+        json_file_name: str = None,
+        force_update: bool = False,
+    ) -> SpecModel:
+        """Merge two DICOM SpecModel objects using the node merge method, with optional caching.
+
+        This is a convenience method that calls merge_many with two models.
+
+        Args:
+            model1 (SpecModel): The first model.
+            model2 (SpecModel): The second model to merge with the first.
+            match_by (str, optional): "name" to match by node name, "attribute" to match by a specific attribute.
+            attribute_name (str, optional): The attribute name to use for matching.
+            merge_attrs (list[str], optional): List of attribute names to merge from the other model's node.
+            json_file_name (str, optional): If provided, cache/load the merged model to/from this file.
+            force_update (bool, optional): If True, always perform the merge and overwrite the cache.
+
+        Returns:
+            SpecModel: The merged SpecModel instance.
+
+        """
+        return self.merge_many(
+            [model1, model2],
+            method = "matching_node",
+            match_by=match_by,
+            attribute_names=[attribute_name],
+            merge_attrs_list=[merge_attrs],
+            json_file_name=json_file_name,
+            force_update=force_update,
+        )
+
+    def merge_path(
+        self,
+        model1: SpecModel,
+        model2: SpecModel,
+        match_by: str = "name",
+        attribute_name: str = None,
+        merge_attrs: list[str] = None,
+        json_file_name: str = None,
+        force_update: bool = False,
+    ) -> SpecModel:
+        """Merge two DICOM SpecModel objects using the path merge method, with optional caching.
+
+        This is a convenience method that calls merge_many with two models.
+
+        Args:
+            model1 (SpecModel): The first model.
+            model2 (SpecModel): The second model to merge with the first.
+            match_by (str, optional): "name" to match by node name, "attribute" to match by a specific attribute.
+            attribute_name (str, optional): The attribute name to use for matching.
+            merge_attrs (list[str], optional): List of attribute names to merge from the other model's node.
+            json_file_name (str, optional): If provided, cache/load the merged model to/from this file.
+            force_update (bool, optional): If True, always perform the merge and overwrite the cache.
+
+        Returns:
+            SpecModel: The merged SpecModel instance.
+
+        """
+        return self.merge_many(
+            [model1, model2],
+            method = "matching_path",
+            match_by=match_by,
+            attribute_names=[attribute_name],
+            merge_attrs_list=[merge_attrs],
+            json_file_name=json_file_name,
+            force_update=force_update,
+        )
+
+    def merge_many(
+        self,
+        models: list[SpecModel],
+        method: str = "matching_path",
+        match_by: str = "name",
+        attribute_names: list = None,
+        merge_attrs_list: list = None,
+        json_file_name: str = None,
+        force_update: bool = False,
+    ) -> SpecModel:
+        """Merge a sequence of DICOM SpecModel objects using the specified merge method, with optional caching.
+
+        This method merges a list of models in order, applying either path-based or node-based
+        merging at each step. You can specify different attribute names and lists of attributes
+        to merge for each step, allowing for flexible, multi-stage enrichment of DICOM models.
+        If json_file_name is provided, the merged model will be cached to that file, and loaded from
+        cache if available and force_update is False.
+
+        Args:
+            models (list of SpecModel): The models to merge, in order.
+            method (str): Merge method to use ("matching_path" or "matching_node").
+            match_by (str, optional): "name" to match by node name, "attribute" to match by a specific attribute.
+            attribute_names (list, optional): List of attribute names to use for each merge step.
+                Each entry corresponds to a merge operation between two models.
+            merge_attrs_list (list, optional): List of lists of attribute names to merge for each merge step.
+                Each entry corresponds to a merge operation between two models.
+            json_file_name (str, optional): If provided, cache/load the merged model to/from this file.
+            force_update (bool, optional): If True, always perform the merge and overwrite the cache.
+
+        Returns:
+            SpecModel: The final merged SpecModel instance.
+
+        Raises:
+            ValueError: If models is empty, method is unknown, or attribute_names/merge_attrs_list
+                have incorrect length.
+
+        """
+        orig_col2attr = None
+        if models and hasattr(models[0].metadata, "column_to_attr"):
+            orig_col2attr = models[0].metadata.column_to_attr
+        cached_model = self._load_merged_model_from_cache(json_file_name, force_update, merge_attrs_list, orig_col2attr)
+        if cached_model is not None:
+            return cached_model
+
+        self._validate_merge_args(models, attribute_names, merge_attrs_list)
+        merged = self._merge_models(
+            models, method=method, match_by=match_by, attribute_names=attribute_names, merge_attrs_list=merge_attrs_list
+            )
+        self._update_metadata(merged, models, merge_attrs_list)
+        self._save_cache(merged, json_file_name)
+        return merged
+
+    def _validate_merge_args(
+        self,
+        models: list[SpecModel],
+        attribute_names: list,
+        merge_attrs_list: list,
+    ) -> None:
+        """Validate and normalize merge arguments for merging models."""
+        if not models:
+            raise ValueError("No models to merge")
+        n_merges = len(models) - 1
+        if attribute_names is None:
+            attribute_names = [None] * n_merges
+        elif not isinstance(attribute_names, list):
+            attribute_names = [attribute_names] * n_merges
+        if merge_attrs_list is None:
+            merge_attrs_list = [None] * n_merges
+        elif (
+            not isinstance(merge_attrs_list, list)
+            or (
+                merge_attrs_list
+                and not isinstance(merge_attrs_list[0], list)
+            )
+        ):
+            merge_attrs_list = [merge_attrs_list] * n_merges
+        if len(attribute_names) != n_merges:
+            raise ValueError(
+                f"Length of attribute_names ({len(attribute_names)}) "
+                f"does not match number of merges ({n_merges})"
+            )
+        if len(merge_attrs_list) != n_merges:
+            raise ValueError(
+                f"Length of merge_attrs_list ({len(merge_attrs_list)}) "
+                f"does not match number of merges ({n_merges})"
+                )
+
+    def _merge_models(
+        self,
+        models: list[SpecModel],
+        method: str = "matching_path",
+        match_by: str = "name",
+        attribute_names: list = None,
+        merge_attrs_list: list = None,
+    ) -> SpecModel:
+        """Perform the actual merging of models using the specified method."""
+        merged = models[0]
+        if method not in ("matching_path", "matching_node"):
+            raise ValueError(f"Unknown merge method: {method}")
+
+        for i, model in enumerate(models[1:]):
+            attribute_name = attribute_names[i]
+            merge_attrs = merge_attrs_list[i]
+            if method == "matching_path":
+                merged = merged.merge_matching_path(
+                    model, match_by=match_by, attribute_name=attribute_name, merge_attrs=merge_attrs
+                    )
+            elif method == "matching_node":
+                merged = merged.merge_matching_node(
+                    model, match_by=match_by, attribute_name=attribute_name, merge_attrs=merge_attrs
+                    )
+        return merged
+
+    def _update_metadata(
+        self,
+        merged: SpecModel,
+        models: list[SpecModel],
+        merge_attrs_list: list,
+    ) -> None:
+        """Update the metadata of the merged model to reflect merged attributes."""
+        # Start with the original metadata
+        meta = merged.metadata
+        orig_header = list(getattr(meta, "header", []))
+        orig_col2attr = dict(getattr(meta, "column_to_attr", {}))
+
+        # Find the next available column index
+        next_col = max(int(idx) for idx in orig_col2attr) + 1 if orig_col2attr else 0
+        # For each merged-in model, add new merged attributes if not already present
+        for i, model in enumerate(models[1:]):
+            merge_attrs = merge_attrs_list[i]
+            other_meta = getattr(model, "metadata", None)
+            if other_meta is not None and merge_attrs:
+                other_header = getattr(other_meta, "header", None)
+                other_col2attr = getattr(other_meta, "column_to_attr", None)
+                if other_header and other_col2attr:
+                    for idx, attr in other_col2attr.items():
+                        if attr in merge_attrs and attr not in orig_col2attr.values():
+                            # Add new column for this attribute
+                            if isinstance(other_header, list) and int(idx) < len(other_header):
+                                orig_header.append(other_header[int(idx)])
+                            else:
+                                orig_header.append(attr)
+                            orig_col2attr[next_col] = attr
+                            next_col += 1
+
+        if hasattr(meta, "header"):
+            meta.header = orig_header
+        if hasattr(meta, "column_to_attr"):
+            meta.column_to_attr = orig_col2attr
+
+    def _save_cache(
+        self,
+        merged: SpecModel,
+        json_file_name: str,
+    ) -> None:
+        """Save the merged model to cache if a json_file_name is provided."""
+        if json_file_name:
+            merged_json_file_path = os.path.join(
+                self.config.get_param("cache_dir"), "model", json_file_name
+            )
+            try:
+                self.model_store.save(merged, merged_json_file_path)
+            except Exception as e:
+                self.logger.warning(f"Failed to cache merged model to {merged_json_file_path}: {e}")
+        else:
+            self.logger.info("No json_file_name specified; merged model not cached.")
+
+    def _load_merged_model_from_cache(
+        self,
+        json_file_name: str,
+        force_update: bool,
+        merge_attrs_list: list = None,
+        orig_col2attr: dict = None,
+    ) -> SpecModel | None:
+        """Return the cached merged model if available, valid, and not force_update, else None."""
+        merged_json_file_path = None
+        if json_file_name:
+            merged_json_file_path = os.path.join(
+                self.config.get_param("cache_dir"), "model", json_file_name
+            )
+        if merged_json_file_path and os.path.exists(merged_json_file_path) and not force_update:
+            try:
+                model = self.model_store.load(merged_json_file_path)
+                # Check that all requested merge attributes are present in the cached model's metadata
+                if merge_attrs_list:
+                    all_attrs = set()
+                    for attrs in merge_attrs_list:
+                        if attrs:
+                            all_attrs.update(attrs)
+                    col2attr = getattr(model.metadata, "column_to_attr", {})
+                    orig_attrs = set(orig_col2attr.values()) if orig_col2attr else set()
+                    # All requested attributes must be present
+                    if any(attr not in col2attr.values() for attr in all_attrs):
+                        self.logger.info(
+                            f"Cached model at {merged_json_file_path} missing required merged attributes {all_attrs}; "
+                            f"ignoring cache."
+                        )
+                        return None
+                    # No extra attributes except those in the original model
+                    allowed_attrs = all_attrs | orig_attrs
+                    extra_attrs = set(col2attr.values()) - allowed_attrs
+                    if extra_attrs:
+                        self.logger.info(
+                            f"Cached model at {merged_json_file_path} contains extra attributes {extra_attrs} "
+                            f"not requested; ignoring cache."
+                        )
+                        return None
+                self.logger.info(
+                    f"Loaded model from cache {merged_json_file_path}"
+                )
+                return model
+            except Exception as e:
+                self.logger.warning(
+                    f"Failed to load merged model from cache {merged_json_file_path}: {e}"
+                )
+        return None

--- a/src/dcmspec/spec_model.py
+++ b/src/dcmspec/spec_model.py
@@ -288,7 +288,8 @@ class SpecModel:
             other (SpecModel): The other model to merge with.
             match_by (str): "name" to match by node name, or "attribute" to match by a specific attribute.
             attribute_name (str, optional): The attribute name to use for matching if match_by="attribute".
-            is_path_based (bool): If True, use the full path of names/attributes as the key; if False, use only the value.
+            is_path_based (bool): If True, use the full path of names/attributes as the key; if False, 
+                use only the value.
 
         Returns:
             tuple: (node_map, key_func)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Shared pytest fixtures for the dcmspec test suite."""
 
+from anytree import Node
 import pytest
+
+from dcmspec.spec_model import SpecModel
 
 @pytest.fixture(autouse=True)
 def patch_dirs(monkeypatch, tmp_path):
@@ -11,3 +14,134 @@ def patch_dirs(monkeypatch, tmp_path):
     monkeypatch.setattr("dcmspec.config.user_config_dir", lambda app_name: str(config_dir))
     # print(f"Test temp directory {tmp_path}")  # Uncomment for debugging with pytest -s
     return tmp_path
+
+
+def make_spec_model_with_seq(
+    top_attrs: dict,
+    seq_attrs: dict,
+    nested_attrs: dict = None,
+    metadata_attrs: dict = None,
+) -> SpecModel:
+    """Create a SpecModel with a sequence.
+
+    - a top-level node ("my_element") under content,
+    - a node ("my_seq_element") under content,
+    - optionally, a nested node ("my_element") under "my_seq_element" if nested_attrs is provided.
+    - metadata_attrs: dict of attributes to set on the metadata node (e.g., header, column_to_attr)
+    """
+    metadata = Node("metadata")
+    if metadata_attrs:
+        for k, v in metadata_attrs.items():
+            setattr(metadata, k, v)
+    content = Node("content")
+    # Top-level node
+    top_node = Node("my_element", parent=content)
+    for k, v in top_attrs.items():
+        setattr(top_node, k, v)
+    # Sequence node
+    seq_node = Node("my_seq_element", parent=content)
+    for k, v in seq_attrs.items():
+        setattr(seq_node, k, v)
+    # Add nested node under sequence
+    if nested_attrs is not None:
+        # Simulate Part 3 parsing: nested node name has leading '>'
+        nested_node = Node(">my_element", parent=seq_node)
+        for k, v in nested_attrs.items():
+            setattr(nested_node, k, v)
+
+    return SpecModel(metadata=metadata, content=content)
+
+@pytest.fixture
+def merge_by_path_test_models():
+    """Create current and other SpecModel for merge_matching_path tests."""
+    metadata_attrs = {
+        "header": ["Element Name", "Tag"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag"},
+    }
+    current = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        metadata_attrs=metadata_attrs,
+    )
+    metadata_attrs = {
+        "header": ["Element Name", "Tag", "N-SET"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag", 2: "n-set"},
+    }
+    other = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "2"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "n-set": "1"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "3"},
+        metadata_attrs=metadata_attrs,
+    )
+    return current, other
+
+@pytest.fixture
+def merge_by_node_test_models():
+    """Create current and other SpecModel for merge_matching_node tests."""
+    metadata_attrs = {
+        "header": ["Element Name", "Tag"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag"},
+    }
+    current = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        metadata_attrs=metadata_attrs,
+    )
+    metadata_attrs = {
+        "header": ["Element Name", "Tag", "VR"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag", 2: "vr"},
+    }
+    other = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "vr": "DS"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "vr": "CS"},
+        metadata_attrs=metadata_attrs,
+    )
+    return current, other
+
+@pytest.fixture
+def merge_test_models_different_path():
+    """Create current and other SpecModel for merge_matching_path tests."""
+    current = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+    )
+    other = make_spec_model_with_seq(
+        {"elem_name": "Different", "elem_tag": "DIFFERENT", "n-set": "2"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "n-set": "1"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "3"},
+    )
+    return current, other
+
+@pytest.fixture
+def mergemany_by_node_test_models():
+    """Create current and other SpecModel for merge_matching_node tests."""
+    metadata_attrs = {
+        "header": ["Element Name", "Tag"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag"},
+    }
+    current = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)"},
+        metadata_attrs=metadata_attrs
+    )
+    metadata_attrs = {
+        "header": ["Element Name", "Tag", "N-SET"],
+        "column_to_attr": {0: "elem_name", 1: "elem_tag", 2: "n-set"},
+    }    
+    second = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "2"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "n-set": "1"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "3"},
+        metadata_attrs=metadata_attrs
+    )
+    third = make_spec_model_with_seq(
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "R+"},
+        {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "n-set": "R+*"},
+        {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "O"},
+        metadata_attrs=metadata_attrs
+    )
+    return current, second, third

--- a/tests/test_spec_factory.py
+++ b/tests/test_spec_factory.py
@@ -144,8 +144,7 @@ def test_build_model(monkeypatch, patch_dirs):
         url="http://example.com",
         # json_file_name is omitted
     )
-    expected_path = str(patch_dirs / "cache" / "model" / "file.json")
-    assert ms.saved[1] == expected_path
+    assert ms.saved is None
     assert tp.called
 
 def test_build_model_with_custom_model_class(monkeypatch, patch_dirs):

--- a/tests/test_spec_merger.py
+++ b/tests/test_spec_merger.py
@@ -1,0 +1,307 @@
+
+"""Tests for the SpecMerger class in dcmspec.spec_merger.
+
+This module provides tests for the SpecMerger class, which merges DICOM specification models
+using both path-based and node-based strategies. The tests verify that merging works as expected
+for both strategies, including cases where nodes with the same attribute value appear at different
+levels in the tree.
+"""
+from anytree import Node
+import pytest
+from pathlib import Path
+from dcmspec.spec_merger import SpecMerger
+
+@pytest.fixture
+def merger(patch_dirs):
+    """Fixture to provide a SpecMerger instance with a patched cache dir."""
+    return SpecMerger(config=None, model_store=None, logger=None)
+
+def assert_node_attrs(node: Node, expected: dict) -> None:
+    """Assert that a node has all expected attributes with expected values (helper function)."""
+    for k, v in expected.items():
+        assert getattr(node, k) == v
+
+def test_specmerger_merge_node(merge_by_node_test_models, merger):
+    """Test SpecMerger.merge_node merges all nodes with matching attribute value, regardless of path.
+
+    This test verifies that node-based merging applies the merged attribute to all nodes
+    with the same attribute value (here, 'elem_tag'), even if they are at different levels in the tree.
+    """
+    # Arrange
+    current, other = merge_by_node_test_models
+
+    # Act
+    merged = merger.merge_node(current, other, match_by="attribute", attribute_name="elem_tag", merge_attrs=["vr"])
+
+    # Assert: top-level and nested "my_element" should get the same "vr" value from other
+    merged_first = next(child for child in merged.content.children if child.name == "my_element")
+    assert_node_attrs(merged_first, {"elem_name": "My Element", "elem_tag": "(0101,1011)", "vr": "DS"})
+    merged_parent = next(child for child in merged.content.children if child.name == "my_seq_element")
+    assert_node_attrs(merged_parent, {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "vr": "CS"})
+    merged_child = next(child for child in merged_parent.children if getattr(child, "elem_tag", None) == "(0101,1011)")
+    assert_node_attrs(merged_child, {"elem_name": "My Element", "elem_tag": "(0101,1011)", "vr": "DS"})
+
+    # Assert: metadata includes all expected attributes (original + merged)
+    expected_attrs = ["elem_name", "elem_tag", "vr"]
+    # Robustly handle int/str keys in column_to_attr
+    col2attr = merged.metadata.column_to_attr
+    # Convert all keys to int for sorting, but keep the original key for lookup
+    sorted_items = sorted(
+        col2attr.items(), 
+        key=lambda item: int(item[0]) if isinstance(item[0], (int, str)) and str(item[0]).isdigit() else float('inf'))
+    actual_attrs = [v for k, v in sorted_items]
+    assert actual_attrs == expected_attrs
+    # Also check that the header includes the new column
+    assert any("vr" in h.lower() for h in merged.metadata.header)
+
+def test_specmerger_merge_path(merge_by_path_test_models, merger):
+    """Test SpecMerger.merge_path merges only nodes with matching attribute path.
+
+    This test verifies that path-based merging applies the merged attribute only to nodes
+    whose full path (including all ancestors) matches between the two models.
+    """
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Act
+    merged = merger.merge_path(current, other, attribute_name="elem_tag", merge_attrs=["n-set"])
+
+    # Assert: top-level and nested "my_element" should get different "n-set" value from other
+    merged_first = next(child for child in merged.content.children if child.name == "my_element")
+    assert_node_attrs(merged_first, {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "2"})
+    merged_parent = next(child for child in merged.content.children if child.name == "my_seq_element")
+    assert_node_attrs(merged_parent, {"elem_name": "My Element Sequence", "elem_tag": "(0101,1010)", "n-set": "1"})
+    merged_child = next(child for child in merged_parent.children if getattr(child, "elem_tag", None) == "(0101,1011)")
+    assert_node_attrs(merged_child, {"elem_name": "My Element", "elem_tag": "(0101,1011)", "n-set": "3"})
+    
+    # Assert: metadata includes all expected attributes (original + merged)
+    expected_attrs = ["elem_name", "elem_tag", "n-set"]
+    col2attr = merged.metadata.column_to_attr
+    # Convert all keys to int for sorting, but keep the original key for lookup
+    sorted_items = sorted(
+        col2attr.items(),
+        key=lambda item: int(item[0]) if isinstance(item[0], (int, str)) and str(item[0]).isdigit() else float('inf')
+    )
+    actual_attrs = [v for k, v in sorted_items]
+    assert actual_attrs == expected_attrs
+    # Also check that the header includes the new column
+    assert any("n-set" in h.lower() for h in merged.metadata.header)
+
+def test_specmerger_merge_many_chained(mergemany_by_node_test_models, merger):
+    """Test SpecMerger.merge_many merges more than two models in sequence."""
+    # Arrange    
+    current, second, third = mergemany_by_node_test_models
+
+    merged = merger.merge_many(
+        [current, second, third],
+        method="matching_path",
+        attribute_names=[ "elem_tag", "elem_tag" ],
+        merge_attrs_list=[ ["n-set"], ["n-set"] ]
+    )
+    # Assert: values from third model should be present
+    merged_first = next(child for child in merged.content.children if child.name == "my_element")
+    assert getattr(merged_first, "n-set") == "R+"
+    merged_parent = next(child for child in merged.content.children if child.name == "my_seq_element")
+    assert getattr(merged_parent, "n-set") == "R+*"
+    merged_child = next(child for child in merged_parent.children if getattr(child, "elem_tag", None) == "(0101,1011)")
+    assert getattr(merged_child, "n-set") == "O"
+
+    # Assert: metadata includes all expected attributes (original + merged)
+    expected_attrs = ["elem_name", "elem_tag", "n-set"]
+    col2attr = merged.metadata.column_to_attr
+    # Convert all keys to int for sorting, but keep the original key for lookup
+    sorted_items = sorted(
+        col2attr.items(),
+        key=lambda item: int(item[0]) if isinstance(item[0], (int, str)) and str(item[0]).isdigit() else float('inf')
+    )
+    actual_attrs = [v for k, v in sorted_items]
+    assert actual_attrs == expected_attrs
+    # Also check that the header includes the new column
+    assert any("n-set" in h.lower() for h in merged.metadata.header)
+
+def test_specmerger_merge_many_empty(merger):
+    """Test SpecMerger.merge_many raises ValueError if models is empty."""
+    with pytest.raises(ValueError):
+        merger.merge_many([])
+
+def test_specmerger_merge_many_mismatched_attribute_names(merge_by_path_test_models, merger):
+    """Test SpecMerger.merge_many raises ValueError if attribute_names length is wrong."""
+    current, other = merge_by_path_test_models
+    with pytest.raises(ValueError):
+        merger.merge_many([current, other], method="matching_path", attribute_names=["elem_tag", "extra"])
+
+def test_specmerger_merge_many_mismatched_merge_attrs_list(merge_by_path_test_models, merger):
+    """Test SpecMerger.merge_many raises ValueError if merge_attrs_list length is wrong."""
+    current, other = merge_by_path_test_models
+    with pytest.raises(ValueError):
+        merger.merge_many([current, other], method="matching_path", merge_attrs_list=[["n-set"], ["extra"]])
+
+def test_specmerger_merge_many_unknown_method(merge_by_path_test_models, merger):
+    """Test SpecMerger.merge_many raises ValueError for unknown method."""
+    current, other = merge_by_path_test_models
+    with pytest.raises(ValueError):
+        merger.merge_many([current, other], method="unknown")
+
+def test_specmerger_merge_node_and_path_defaults(merge_by_path_test_models, merger):
+    """Test SpecMerger.merge_node and merge_path with default attribute_name and merge_attrs."""
+    current, other = merge_by_path_test_models
+    # Should not raise or fail, just not merge any new attributes
+    merged_node = merger.merge_node(current, other)
+    merged_path = merger.merge_path(current, other)
+    # The structure should be preserved
+    assert any(child.name == "my_element" for child in merged_node.content.children)
+    assert any(child.name == "my_seq_element" for child in merged_path.content.children)
+
+
+def test_specmerger_merge_many_saves_cache(
+    merge_by_path_test_models, merger, patch_dirs, monkeypatch
+):
+    """Test that merge_many saves cache file when json_file_name is present and force_update is not set."""
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Patch the save method of the model_store instance to capture its arguments
+    saved = {}
+
+    def fake_save(model, path):
+        saved["model"] = model
+        saved["path"] = path
+
+    monkeypatch.setattr(merger.model_store, "save", fake_save)
+
+    # Act
+    json_file_name = "test_merged.json"
+    merged = merger.merge_many(
+        [current, other],
+        method="matching_path",
+        attribute_names=["elem_tag"],
+        merge_attrs_list=[["n-set"]],
+        json_file_name=json_file_name,
+    )
+
+    # Assert path to saved json file and call to SpecStore save method
+    expected_path = str(Path(patch_dirs) / "cache" / "model" / json_file_name)
+    assert saved["path"] == expected_path
+    assert saved["model"] is merged
+
+
+def test_specmerger_merge_many_save_failure_logs_warning(
+    merge_by_path_test_models, merger, patch_dirs, monkeypatch, caplog
+):
+    """Test that merge_many logs a warning if saving the cache file fails."""
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Patch the save method of the model_store instance to simulate failure
+    def fail_save(model, path):
+        raise IOError("Simulated save failure")
+
+    monkeypatch.setattr(merger.model_store, "save", fail_save)
+
+    # Act
+    json_file_name = "fail_merged.json"
+    with caplog.at_level("WARNING"):
+        merger.merge_many(
+            [current, other],
+            method="matching_path",
+            attribute_names=["elem_tag"],
+            merge_attrs_list=[["n-set"]],
+            json_file_name=json_file_name,
+        )
+
+    # Assert log warning message
+    assert any(
+        "Failed to cache merged model" in record.message and "Simulated save failure" in record.message
+        for record in caplog.records
+    )
+
+class DummyModel:
+    """Minimal stand-in for SpecModel for cache validation tests.
+
+    This dummy model mimics the minimal interface of a SpecModel required for cache tests:
+    it has a .metadata attribute, which is an anytree Node with a .column_to_attr attribute.
+    """
+
+    def __init__(self, attrs):
+        """Initialize DummyModel with a metadata node.
+
+        Args:
+            attrs (dict): The column_to_attr mapping to set on the metadata node.
+
+        """
+        self.metadata = Node("metadata")
+        self.metadata.column_to_attr = attrs
+
+def test_specmerger_merge_many_loads_cache_valid(
+    merge_by_path_test_models, merger, patch_dirs, monkeypatch
+):
+    """Test that merge_many loads the merged model from cache if present, valid, and force_update is False."""
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Patch model_store load to simulate all requested attributes present, no extra attributes
+    dummy_model_valid = DummyModel({0: "elem_name", 1: "elem_tag", 2: "n-set"})
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr(merger.model_store, "load", lambda path: dummy_model_valid)
+
+    # Act
+    json_file_name = "cached_merged.json"
+    merged = merger.merge_many(
+        [current, other],
+        method="matching_path",
+        attribute_names=["elem_tag"],
+        merge_attrs_list=[["n-set"]],
+        json_file_name=json_file_name,
+    )
+
+    # Assert cache is used
+    assert merged is dummy_model_valid
+
+def test_specmerger_merge_many_loads_cache_missing_attr(
+    merge_by_path_test_models, merger, patch_dirs, monkeypatch
+):
+    """Test that merge_many does not use cache if a requested attribute is missing."""
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Patch model_store load to simulate missing requested attribute
+    dummy_model_missing = DummyModel({0: "elem_name", 1: "elem_tag"})
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr(merger.model_store, "load", lambda path: dummy_model_missing)
+    json_file_name = "cached_merged.json"
+    merged = merger.merge_many(
+        [current, other],
+        method="matching_path",
+        attribute_names=["elem_tag"],
+        merge_attrs_list=[["n-set"]],
+        json_file_name=json_file_name,
+    )
+
+    # Assert: cache should not be used if a requested attribute is missing
+    assert merged is not dummy_model_missing
+
+def test_specmerger_merge_many_loads_cache_extra_attr(
+    merge_by_path_test_models, merger, patch_dirs, monkeypatch
+):
+    """Test that merge_many does not use cache if there is an extra attribute not in original or requested."""
+    # Arrange    
+    current, other = merge_by_path_test_models
+
+    # Patch model_store load to simulate extra attribute present
+    dummy_model_extra = DummyModel({0: "elem_name", 1: "elem_tag", 2: "n-set", 3: "extra"})
+
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+    monkeypatch.setattr(merger.model_store, "load", lambda path: dummy_model_extra)
+    json_file_name = "cached_merged.json"
+    merged = merger.merge_many(
+        [current, other],
+        method="matching_path",
+        attribute_names=["elem_tag"],
+        merge_attrs_list=[["n-set"]],
+        json_file_name=json_file_name,
+    )
+
+    # Assert: cache should not be used if an extra attribute is present
+    assert merged is not dummy_model_extra


### PR DESCRIPTION
Add model merging functionality
- Add SpecMerger class for merging DICOM specification models
- Add merge_matching_path and merge_matching_node methods to SpecModel
- Refactor SpecFactory to extract try_load_cache method
- Add comprehensive test suite for merging functionality
- Update CLI to support merging and enrichment with Part 6

## Summary by Sourcery

Add comprehensive model merging support by implementing path-based and node-based merge methods on SpecModel, introducing a reusable SpecMerger class with caching and metadata enrichment, refactoring SpecFactory cache loading, and extending the modattributes CLI to merge and enrich models from Part 6. Include documentation updates and a full test suite for the new merging capabilities.

New Features:
- Add SpecModel.merge_matching_path for path-based merging of two models
- Add SpecModel.merge_matching_node for node-based merging across entire model trees
- Introduce SpecMerger class with merge_node, merge_path, and merge_many methods supporting caching and metadata updates
- Extend modattributes CLI with --add-part6 and --force-update options to enrich module models using Part 6 data

Enhancements:
- Refactor SpecFactory by extracting try_load_cache and simplifying cache loading logic
- Improve logging setup in SpecModel and the modattributes CLI

Documentation:
- Add SpecMerger API entry in mkdocs.yml and create spec_merger.md documentation

Tests:
- Add fixtures and tests for merge_matching_path and merge_matching_node in test_spec_model.py
- Add comprehensive tests for SpecMerger methods, merge_many caching behavior, and error handling in test_spec_merger.py
- Update test_spec_factory.py to reflect new cache behavior