### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,25 @@
 
 **dcmspec** is a versatile **Python toolkit** designed to provide processing of _DICOM specifications_ from the _DICOM standard_ or _IHE profiles_.
 
+Designed as a general-purpose, extensible framework, **dcmspec** enables flexible extraction, parsing, and processing of specification tables.
+
 ## Features
 
-- An **[API](https://dwikler.github.io/dcmspec/api/)** to programmatically access, parse, and process DICOM and IHE specification tables.
-- **[Command-Line Interface (CLI) Sample Scripts](https://dwikler.github.io/dcmspec/cli/)** which extract, parse, and process DICOM and IHE specification tables.
+- An API to programmatically access, parse, and process DICOM and IHE specification tables.
+- Command-Line Interface (CLI) Sample Scripts which extract, parse, and process specific DICOM and IHE specification tables.
 
-## Installation and Configuration
+## Installation
 
-Installation and configuration instructions for CLI script users and developers are detailed in the project documentation.
+See the [Installation Guide](https://dwikler.github.io/dcmspec/installation/) for detailed instructions.
 
-- [Installation Guide](https://dwikler.github.io/dcmspec/installation/)
-- [Configuration & Caching](https://dwikler.github.io/dcmspec/configuration/)
+## Usage
+
+- For API usage, see the [API documentation](https://dwikler.github.io/dcmspec/api/).
+- For CLI usage, see the [CLI Applications Overview](https://dwikler.github.io/dcmspec/cli/).
+
+## Configuration
+
+See [Configuration & Caching](https://dwikler.github.io/dcmspec/configuration/) for details on configuring cache and other settings.
 
 ## Contributing
 
@@ -43,7 +51,7 @@ If you want to contribute to the project, follow these steps:
 
 ## Similar Projects
 
-There are a few great related open source projects that I highly recommend.
+There are a few great related open source projects worth checking out:
 
 - [innolitics/dicom-standard](https://github.com/innolitics/dicom-standard): Tools and data for parsing and working with the DICOM standard in a structured format.
 - [pydicom/dicom-validator](https://github.com/pydicom/dicom-validator): A DICOM file validator based on the DICOM standard.

--- a/README.md
+++ b/README.md
@@ -4,32 +4,21 @@
 
 ## Overview
 
-**dcmspec** is a versatile toolkit designed to provide processing of DICOM specifications from the DICOM standard or IHE documents. It aims to streamline the process of parsing, extracting, and using DICOM specifications to support software developers in leveraging DICOM within their applications. It also provides CLI applications which converts parts of the DICOM standard into a structured representation.
+**dcmspec** is a versatile **Python toolkit** designed to provide processing of _DICOM specifications_ from the _DICOM standard_ or _IHE profiles_.
 
 ## Features
 
-- **Attribute Requirements Parsing from DICOM Standard**: Extract attributes requirements from tables in DICOM standard XHTML files.
-- **Attribute Requirements Parsing from IHE Technical Framework or Supplements**: Extract attributes requirements from tables in IHE Technical Framework or Supplements PDF files.
+- An **[API](https://dwikler.github.io/dcmspec/api/)** to programmatically access, parse, and process DICOM and IHE specification tables.
+- **[Command-Line Interface (CLI) Sample Scripts](https://dwikler.github.io/dcmspec/cli/)** which extract, parse, and process DICOM and IHE specification tables.
 
-## For Developers
+## Installation and Configuration
 
-### Installation Using Poetry
+Installation and configuration instructions for CLI script users and developers are detailed in the project documentation.
 
-To install the package using Poetry, follow these steps:
+- [Installation Guide](https://dwikler.github.io/dcmspec/installation/)
+- [Configuration & Caching](https://dwikler.github.io/dcmspec/configuration/)
 
-1. **Add the following to your `pyproject.toml`**:
-
-   ```toml
-   [tool.poetry.dependencies]
-   dcmspec = { git = "https://github.com/dwikler/dcmspec.git", tag = "v0.1.0" }
-   ```
-
-2. **Install the Dependencies**:
-   ```bash
-   poetry install
-   ```
-
-### Contributing
+## Contributing
 
 If you want to contribute to the project, follow these steps:
 
@@ -47,71 +36,20 @@ If you want to contribute to the project, follow these steps:
    ```
 
 3. **Activate the virtual environment**:
+
    ```bash
    poetry shell
    ```
 
-## Command-Line Interface (CLI) Applications
+## Similar Projects
 
-After installing and activating your environment, you can use the CLI tools provided by **dcmspec**.
+There are a few great related open source projects that I highly recommend.
 
-### DICOM Standard Parsers Scripts
+- [innolitics/dicom-standard](https://github.com/innolitics/dicom-standard): Tools and data for parsing and working with the DICOM standard in a structured format.
+- [pydicom/dicom-validator](https://github.com/pydicom/dicom-validator): A DICOM file validator based on the DICOM standard.
 
-- `dataelements`: parses Data Elements definitions from Part 6: Data Dictionary
-- `uidvalues`: parses Unique Identifiers (UIDs) definitions from Part 6: Data Dictionary
-- `modattributes`: parses Module Attributes specification from Part 3: Information Object Definitions
-- `upsattributes`: parses UPS Attributes specification from Part 4: Service Class Specifications
+**How dcmspec differs:**
 
-The DICOM Standards documents and their structured data models will be saved in the default cache folder or in a folder you define using the configuration file.
-
-```json
-{
-  "cache_dir": "./cache"
-}
-```
-
-The config file can be created as config.json in the default configuration folder or its location can be specified using the --config option or using the `DCMSPEC_CONFIG` environment variable.
-
-The default cache and configuration folders location depends on the platform.
-
-MacOS:
-
-- Default cache folder: ~/Library/Caches/dcmspec
-- Default configuration folder: ~/Library/Application Support/dcmspec
-
-Linux:
-
-- Default cache folder: ~/.cache/dcmspec
-- Default configuration folder: ~/.config/dcmspec
-
-Windows:
-
-- Default cache folder: %USERPROFILE%\AppData\Local\dcmspec\Cache
-- Default configuration folder: %USERPROFILE%\AppData\Local\dcmspec or %USERPROFILE%\AppData\Roaming\dcmspec
-
-~/.cache/dcmspec
-
-### Example: Parsing a DICOM IOD Module Attributes Table
-
-To parse the Part 6 Data Elements table and print it as an ASCII table,
-
-- **run the CLI app module as a script:**
-
-  ```bash
-  poetry run python -m src.dcmspec.cli.dataelements
-  ```
-
-- **run the script directly using the registered entry point**  
-  (see `[tool.poetry.scripts]` in `pyproject.toml`)
-
-  ```bash
-  poetry run dataelements
-  ```
-
-- **run the CLI app module as a script directly (without Poetry):**
-
-  ```bash
-  export PYTHONPATH=$(pwd)/src
-  source ./.venv/bin/activate
-  python -m dcmspec.cli.dataelements
-  ```
+- The above projects focus on parsing specific sections of the DICOM standard to support targeted use cases, such as browsing or validation.
+- **dcmspec** is designed with a broader scope. It provides a flexible framework for parsing any DICOM specification table from DICOM standard documents and IHE profiles.
+- The object-oriented architecture of **dcmspec** is extensible, making it possible to support additional sources (such as DICOM Conformance Statements) and to define custom structured data models as output.


### PR DESCRIPTION
- Remove redundant infor from README.md and link to documentation on GitHub Pages
- Add Similar Projects section

## Summary by Sourcery

Streamline the README by removing detailed inline installation and CLI instructions in favor of links to the GitHub Pages documentation, reorganizing sections, and adding a Similar Projects comparison.

Documentation:
- Remove redundant installation and usage details and link to online Installation Guide and Configuration documentation.
- Update Features section to reference API and CLI sample scripts on the docs site.
- Reorganize headings to focus on overview, features, installation, contributing, and similar projects.
- Add a Similar Projects section highlighting related tools and contrasting dcmspec’s broader parsing framework.