### PR TITLE
Add DCMspec Explorer GUI app

### DIFF
--- a/docs/apps/dcmspec-explorer.md
+++ b/docs/apps/dcmspec-explorer.md
@@ -1,0 +1,64 @@
+# DCMSPEC Explorer
+
+A GUI application for exploring DICOM specifications interactively.
+
+## Running the Application
+
+### Option 1: Using poetry run (recommended)
+```bash
+poetry run dcmspec-explorer
+```
+
+### Option 2: Activate environment then run directly
+```bash
+# On Windows PowerShell
+.\.venv\Scripts\Activate.ps1
+dcmspec-explorer
+
+# On Unix/macOS
+source .venv/bin/activate
+dcmspec-explorer
+```
+
+### Option 3: Using the module path
+```bash
+poetry run python -m src.dcmspec.apps.dcmspec_explorer.dcmspec_explorer
+```
+
+### Note on Poetry 2.0+ Environment Activation
+
+If you're using Poetry 2.0+, the `poetry env activate` command only prints the activation command but doesn't actually activate the environment in your current shell. For direct command execution, use one of these approaches:
+
+- **Manual activation (Windows):** `.\.venv\Scripts\Activate.ps1`
+- **Install shell plugin:** `poetry self add poetry-plugin-shell` then use `poetry shell`
+- **Always use `poetry run`:** No activation needed
+
+## Configuration
+
+The application supports customizable configuration through JSON files. Configuration files are searched in the following order:
+
+1. Current directory: `dcmspec_explorer_config.json`
+2. User config: `~/.config/dcmspec/dcmspec_explorer_config.json`
+3. App config directory: `src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config.json`
+4. Legacy location: Same directory as script
+
+For detailed configuration options and examples, see the config directory in the application source.
+
+## Features
+
+- Browse DICOM IODs (Information Object Definitions)
+- Explore IOD modules and attributes hierarchically
+- Sort and filter IOD lists
+- Configurable logging levels
+- Persistent caching of downloaded specifications
+- Context menus for advanced options
+
+## Configuration Examples
+
+The application includes several example configurations:
+
+- **Default**: Basic configuration with INFO logging
+- **Debug**: Verbose logging for troubleshooting
+- **Minimal**: Minimal logging for production use
+
+Copy any example to one of the search locations and rename to `dcmspec_explorer_config.json` to use it.

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -1,0 +1,13 @@
+# Applications
+
+DCMspec includes interactive applications for exploring DICOM specifications.
+
+## Available Applications
+
+- [DCMSPEC Explorer](dcmspec-explorer.md) - Interactive application for browsing DICOM IODs and modules
+
+## Getting Started
+
+All applications can be launched using Poetry. Make sure you have completed the [installation](../installation.md) steps first.
+
+For configuration and caching information, see the [Configuration & Caching](../configuration.md) page.

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -1,10 +1,10 @@
 # Applications
 
-DCMspec includes interactive applications for exploring DICOM specifications.
+This section documents the sample interactive applications provided by **dcmspec**.
 
 ## Available Applications
 
-- [DCMSPEC Explorer](dcmspec-explorer.md) - Interactive application for browsing DICOM IODs and modules
+- [DCMspec Explorer](dcmspec-explorer.md) - GUI application using Tkinter for browsing DICOM IODs and modules
 
 ## Getting Started
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,10 @@ nav:
       - upsioddimseattributes: cli/upsioddimseattributes.md
       - tdwiicontent: cli/tdwiicontent.md
 
+  - Applications:
+      - Apps Overview: apps/index.md
+      - DCMSPEC Explorer: apps/dcmspec-explorer.md
+
   - API Reference:
       - API Overview: api/index.md
       - Constants Modules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,14 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 dataelements = "dcmspec.cli.dataelements:main"
+iodattributes = "dcmspec.cli.iodattributes:main"
+uidvalues = "dcmspec.cli.uidvalues:main"
+iodmodules = "dcmspec.cli.iodmodules:main"
+upsioddimseattributes = "dcmspec.cli.upsioddimseattributes:main"
+tdwiicontent = "dcmspec.cli.tdwiicontent:main"
+upsdimseattributes = "dcmspec.cli.upsdimseattributes:main"
+modattributes = "dcmspec.cli.modattributes:main"
+dcmspec-explorer = "dcmspec.apps.dcmspec_explorer:main"
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ upsioddimseattributes = "dcmspec.cli.upsioddimseattributes:main"
 tdwiicontent = "dcmspec.cli.tdwiicontent:main"
 upsdimseattributes = "dcmspec.cli.upsdimseattributes:main"
 modattributes = "dcmspec.cli.modattributes:main"
-dcmspec-explorer = "dcmspec.apps.dcmspec_explorer:main"
+dcmspec-explorer = "dcmspec.apps.dcmspec_explorer.dcmspec_explorer:main"
 
 [tool.ruff]
 line-length = 120

--- a/src/dcmspec/apps/__init__.py
+++ b/src/dcmspec/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application interfaces for dcmspec."""

--- a/src/dcmspec/apps/dcmspec_explorer.py
+++ b/src/dcmspec/apps/dcmspec_explorer.py
@@ -16,6 +16,7 @@ from dcmspec.config import Config
 from dcmspec.iod_spec_builder import IODSpecBuilder
 from dcmspec.spec_factory import SpecFactory
 from dcmspec.xhtml_doc_handler import XHTMLDocHandler
+from dcmspec.dom_table_spec_parser import DOMTableSpecParser
 
 
 class DCMSpecExplorer:
@@ -45,6 +46,9 @@ class DCMSpecExplorer:
         self.config = Config(app_name="dcmspec")
         self.doc_handler = XHTMLDocHandler(config=self.config, logger=self.logger)
         
+        # Initialize DOM parser for version extraction
+        self.dom_parser = DOMTableSpecParser(logger=self.logger)
+        
         # Set window size and center it on screen
         window_width = 1000
         window_height = 700
@@ -71,6 +75,9 @@ class DCMSpecExplorer:
         # Store IOD models to keep AnyTree nodes in memory
         self.iod_models = {}  # table_id -> model mapping
         
+        # Store DICOM version
+        self.dicom_version = "Unknown"
+        
         self.setup_ui()
         self.load_iod_modules()
     
@@ -91,6 +98,10 @@ class DCMSpecExplorer:
         # Add refresh button with context menu option
         refresh_btn = ttk.Button(top_frame, text="Reload", command=self.load_iod_modules)
         refresh_btn.pack(side=tk.RIGHT)
+        
+        # Add version label to the left of the button with right justification and spacing
+        self.version_label = ttk.Label(top_frame, text="", font=("Arial", 10), anchor="e")
+        self.version_label.pack(side=tk.RIGHT, padx=(0, 10))
         
         # Add context menu for refresh button
         self._create_refresh_context_menu(refresh_btn)
@@ -236,6 +247,10 @@ class DCMSpecExplorer:
                 url=self.part3_toc_url,
                 force_download=force_download
             )
+            
+            # Extract and display DICOM version using the library method
+            self.dicom_version = self.dom_parser.get_version(soup, "")
+            self.version_label.config(text=f"Version {self.dicom_version}")
             
             # Find the list of tables div
             list_of_tables = soup.find('div', class_='list-of-tables')

--- a/src/dcmspec/apps/dcmspec_explorer.py
+++ b/src/dcmspec/apps/dcmspec_explorer.py
@@ -1,0 +1,619 @@
+"""DCMSPEC Explorer - GUI application for dcmspec.
+
+This module provides a graphical user interface for exploring DICOM specifications,
+allowing users to browse IODs, modules, and attributes through an interactive interface.
+"""
+
+import tkinter as tk
+from tkinter import ttk, messagebox, scrolledtext
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Tuple
+import re
+import logging
+from anytree import PreOrderIter
+
+from dcmspec.config import Config
+from dcmspec.iod_spec_builder import IODSpecBuilder
+from dcmspec.spec_factory import SpecFactory
+
+
+class DCMSpecExplorer:
+    """Main window for the DCMSPEC Explorer application."""
+    
+    def __init__(self, root: tk.Tk):
+        """Initialize the main window."""
+        self.root = root
+        self.root.title("DCMSPEC Explorer")
+        
+        # Initialize logger as instance attribute
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
+        
+        # Create console handler with DEBUG level
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.DEBUG)
+        
+        # Create formatter
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        console_handler.setFormatter(formatter)
+        
+        # Add handler to logger
+        self.logger.addHandler(console_handler)
+        
+        # Set window size and center it on screen
+        window_width = 1000
+        window_height = 700
+        
+        # Get screen dimensions
+        screen_width = root.winfo_screenwidth()
+        screen_height = root.winfo_screenheight()
+        
+        # Calculate position to center the window
+        x = (screen_width - window_width) // 2
+        y = (screen_height - window_height) // 2
+        
+        # Set geometry with centered position
+        self.root.geometry(f"{window_width}x{window_height}+{x}+{y}")
+        
+        # URL for DICOM Part 3 TOC
+        self.dicom_url = "https://dicom.nema.org/medical/dicom/current/output/chtml/part03/ps3.3.html"
+        
+        # Store original data for sorting
+        self.iod_modules_data = []
+        self.sort_column = None
+        self.sort_reverse = False
+        
+        # Store IOD models to keep AnyTree nodes in memory
+        self.iod_models = {}  # table_id -> model mapping
+        
+        self.setup_ui()
+        self.load_iod_modules()
+    
+    def setup_ui(self):
+        """Set up the user interface."""
+        # Create main frame
+        main_frame = ttk.Frame(self.root)
+        main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        
+        # Create top frame for controls
+        top_frame = ttk.Frame(main_frame)
+        top_frame.pack(fill=tk.X, pady=(0, 10))
+        
+        # Add title label
+        title_label = ttk.Label(top_frame, text="DICOM IOD List", font=("Arial", 16, "bold"))
+        title_label.pack(side=tk.LEFT)
+        
+        # Add refresh button
+        refresh_btn = ttk.Button(top_frame, text="Refresh", command=self.load_iod_modules)
+        refresh_btn.pack(side=tk.RIGHT)
+        
+        # Create paned window for treeview and details
+        paned_window = ttk.PanedWindow(main_frame, orient=tk.HORIZONTAL)
+        paned_window.pack(fill=tk.BOTH, expand=True)
+        
+        # Left frame for treeview
+        left_frame = ttk.Frame(paned_window)
+        paned_window.add(left_frame, weight=1)
+        
+        # Create treeview
+        tree_frame = ttk.Frame(left_frame)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+        
+        # Treeview with scrollbar - configure with monospaced font for better tag display
+        self.tree = ttk.Treeview(
+            tree_frame, 
+            columns=("iod_type", "usage"), 
+            show="tree headings"
+        )
+        
+        # Configure monospaced font using TTK style
+        style = ttk.Style()
+        
+        # Configure monospaced font - simple preference stack
+        import tkinter.font as tkfont
+        available_fonts = tkfont.families()
+        
+        # Preferred monospaced fonts in order of preference
+        font_preferences = ["Menlo", "Monaco", "Courier New", "Andale Mono", "TkFixedFont"]
+        
+        # Select the first available font from our preference list
+        selected_font = "TkFixedFont"  # System default monospace fallback
+        
+        for font_name in font_preferences:
+            if font_name in available_fonts or font_name == "TkFixedFont":
+                selected_font = font_name
+                break
+        self.logger.debug(f"Selected monospaced font: {selected_font}")
+        
+        # Configure the treeview with the selected font
+        style.configure("Treeview", font=(selected_font, 10))
+        style.configure("Treeview.Heading", font=("Arial", 10, "bold"))
+        
+        # Verify the configuration
+        actual_font = style.lookup("Treeview", "font")
+        self.logger.debug(f"Final font configuration: {actual_font}")
+        self.tree.heading("#0", text="IOD Name", command=lambda: self.sort_treeview("#0"))
+        self.tree.heading("iod_type", text="IOD Type", command=lambda: self.sort_treeview("iod_type"))
+        self.tree.heading("usage", text="Usage")  # No sorting command
+        self.tree.column("#0", width=400)
+        self.tree.column("iod_type", width=100)
+        self.tree.column("usage", width=80)
+        
+        # Scrollbars for treeview
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL, command=self.tree.yview)
+        tree_scroll_x = ttk.Scrollbar(tree_frame, orient=tk.HORIZONTAL, command=self.tree.xview)
+        self.tree.configure(yscrollcommand=tree_scroll_y.set, xscrollcommand=tree_scroll_x.set)
+        
+        self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        tree_scroll_y.pack(side=tk.RIGHT, fill=tk.Y)
+        tree_scroll_x.pack(side=tk.BOTTOM, fill=tk.X)
+        
+        # Right frame for details
+        right_frame = ttk.Frame(paned_window)
+        paned_window.add(right_frame, weight=1)
+        
+        # Details text area
+        details_label = ttk.Label(right_frame, text="Details", font=("Arial", 12, "bold"))
+        details_label.pack(anchor=tk.W, pady=(0, 5))
+        
+        self.details_text = scrolledtext.ScrolledText(right_frame, wrap=tk.WORD, width=50, height=30)
+        self.details_text.pack(fill=tk.BOTH, expand=True)
+        
+        # Bind treeview selection event
+        self.tree.bind("<<TreeviewSelect>>", self.on_tree_select)
+        
+        # Status bar
+        self.status_var = tk.StringVar()
+        self.status_var.set("Ready")
+        status_bar = ttk.Label(main_frame, textvariable=self.status_var, relief=tk.SUNKEN)
+        status_bar.pack(fill=tk.X, side=tk.BOTTOM, pady=(5, 0))
+    
+    def load_iod_modules(self):
+        """Load IOD modules from the DICOM specification."""
+        self.status_var.set("Loading IOD modules...")
+        self.root.update()
+        
+        try:
+            # Clear existing items
+            for item in self.tree.get_children():
+                self.tree.delete(item)
+            
+            # Download and parse the HTML
+            response = requests.get(self.dicom_url, timeout=30)
+            response.raise_for_status()
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # Find the list of tables div
+            list_of_tables = soup.find('div', class_='list-of-tables')
+            if not list_of_tables:
+                messagebox.showerror("Error", "Could not find list-of-tables section")
+                return
+            
+            # Extract IOD modules
+            iod_modules = self.extract_iod_modules(list_of_tables)
+            
+            # Store the data for sorting
+            self.iod_modules_data = iod_modules
+            
+            # Set initial sort state to show that data is sorted by IOD Name
+            self.sort_column = "#0"
+            self.sort_reverse = False
+            
+            # Populate treeview
+            self.populate_treeview(iod_modules)
+            
+            # Update column headings to show initial sort state
+            self.update_column_headings()
+            
+            self.status_var.set(f"Loaded {len(iod_modules)} IOD modules")
+            
+        except requests.RequestException as e:
+            messagebox.showerror("Network Error", f"Failed to download DICOM specification:\n{str(e)}")
+            self.status_var.set("Error loading modules")
+        except Exception as e:
+            messagebox.showerror("Error", f"An error occurred:\n{str(e)}")
+            self.status_var.set("Error loading modules")
+    
+    def extract_iod_modules(self, list_of_tables) -> List[Tuple[str, str, str, str]]:
+        """Extract IOD modules from the list of tables section.
+        
+        Returns:
+            List of tuples (title, table_id, href, iod_type)
+            
+        """
+        iod_modules = []
+        
+        # Find all dt elements
+        dt_elements = list_of_tables.find_all('dt')
+        
+        for dt in dt_elements:
+            # Find anchor tags within the dt
+            anchor = dt.find('a')
+            if anchor and anchor.get('href'):
+                href = anchor.get('href')
+                text = anchor.get_text(strip=True)
+                
+                # Check if this is an IOD Modules table
+                if 'IOD Modules' in text:
+                    # Extract table ID from href (after the #)
+                    if '#' in href:
+                        table_id = href.split('#')[-1]
+                    else:
+                        # Fallback: try to extract from href path
+                        table_id = href.split('/')[-1].replace('.html', '')
+                    
+                    # Extract the title (remove the table number prefix)
+                    title_match = re.match(r'^[A-Z]?\.\d+(?:\.\d+)*-\d+\.\s*(.+)$', text)
+                    title = title_match[1] if title_match else text
+                    
+                    # Strip " IOD Modules" from the end of the title
+                    if title.endswith(" IOD Modules"):
+                        title = title[:-12]  # Remove " IOD Modules" (12 characters)
+                    
+                    # Determine IOD type based on table_id
+                    if "_A." in table_id:
+                        iod_type = "Composite"
+                    elif "_B." in table_id:
+                        iod_type = "Normalized"
+                    else:
+                        iod_type = "Other"
+                    
+                    iod_modules.append((title, table_id, href, iod_type))
+        
+        return sorted(iod_modules, key=lambda x: x[0])
+    
+    def populate_treeview(self, iod_modules: List[Tuple[str, str, str, str]]):
+        """Populate the treeview with IOD modules."""
+        for title, table_id, href, iod_type in iod_modules:
+            # Store table_id in tags for later retrieval, display iod_type in column
+            self.tree.insert("", tk.END, text=title, values=(iod_type, ""), 
+                           tags=(table_id,))
+    
+    def sort_treeview(self, column: str):
+        """Sort the treeview by the specified column."""
+        # Determine if we need to reverse the sort
+        if self.sort_column == column:
+            self.sort_reverse = not self.sort_reverse
+        else:
+            self.sort_reverse = False
+        
+        self.sort_column = column
+        
+        # Sort the data
+        if column == "#0":  # IOD Name column
+            sorted_data = sorted(self.iod_modules_data, 
+                                key=lambda x: x[0].lower(), 
+                                reverse=self.sort_reverse)
+        elif column == "iod_type":  # IOD Type column
+            sorted_data = sorted(self.iod_modules_data, 
+                                key=lambda x: x[3].lower(), 
+                                reverse=self.sort_reverse)
+        else:
+            # Unknown column, keep original order
+            sorted_data = self.iod_modules_data
+        
+        # Clear the treeview
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        
+        # Repopulate with sorted data
+        self.populate_treeview(sorted_data)
+        
+        # Update column headings to show sort direction
+        self.update_column_headings()
+    
+    def update_column_headings(self):
+        """Update column headings to show sort direction."""
+        # Reset all headings
+        self.tree.heading("#0", text="IOD Name")
+        self.tree.heading("iod_type", text="IOD Type")
+        self.tree.heading("usage", text="Usage")
+        
+        # Add sort indicator to the current sort column
+        if self.sort_column:
+            indicator = " ↓" if self.sort_reverse else " ↑"
+            if self.sort_column == "#0":
+                self.tree.heading("#0", text=f"IOD Name{indicator}")
+            elif self.sort_column == "iod_type":
+                self.tree.heading("iod_type", text=f"IOD Type{indicator}")
+    
+    def on_tree_select(self, event):
+        """Handle treeview selection event."""
+        selection = self.tree.selection()
+        if not selection:
+            return
+        
+        item = selection[0]
+        item_values = self.tree.item(item, "values")
+        title = self.tree.item(item, "text")
+        tags = self.tree.item(item, "tags")
+        
+        # Check if this is a top-level IOD item (has table_id in tags)
+        # Top-level IOD items have table_id starting with "table_", 
+        # while modules/attributes have AnyTree node objects
+        if tags and len(tags) > 0 and isinstance(tags[0], str) and tags[0].startswith("table_"):
+            # This is a top-level IOD item
+            table_id = tags[0]
+            iod_type = item_values[0] if item_values else "Unknown"
+            
+            # Check if this item already has children (IOD structure loaded)
+            if self.tree.get_children(item):
+                # Already loaded, just update details
+                self._update_details_text(table_id, title, iod_type)
+                return
+            
+            # Build the IOD model and populate the tree structure
+            try:
+                self.status_var.set(f"Loading IOD structure for {table_id}...")
+                self.root.update()
+                
+                # Build the IOD model using the same logic as iodattributes.py
+                model = self._build_iod_model(table_id)
+                
+                # Store the model to keep AnyTree nodes in memory
+                self.iod_models[table_id] = model
+                
+                if model and hasattr(model, 'content') and model.content:
+                    # Populate the tree item with the IOD structure
+                    self._populate_iod_structure(item, model.content)
+                    
+                    # Expand the item to show the structure
+                    self.tree.item(item, open=True)
+                
+                self._update_details_text(table_id, title, iod_type)
+                self.status_var.set(f"Loaded structure for {table_id}")
+                
+            except Exception as e:
+                messagebox.showerror("Error", f"Failed to load IOD structure:\n{str(e)}")
+                self.status_var.set(f"Error loading {table_id}")
+                self._update_details_text(table_id, title, iod_type)
+        
+        else:
+            # This is a module or attribute item
+            node_type = item_values[0] if item_values else "Unknown"
+            usage = item_values[1] if len(item_values) > 1 else ""
+            
+            # Get AnyTree node using the node path stored in tags
+            node = None
+            if tags and len(tags) > 0:
+                node_path = tags[0]
+                # Find the node by traversing the path in the appropriate IOD model
+                # First, determine which IOD model this node belongs to by checking parent items
+                current_item = item
+                table_id = None
+                
+                # Walk up the tree to find the root IOD item
+                while current_item:
+                    parent_item = self.tree.parent(current_item)
+                    if not parent_item:  # This is a root item
+                        item_tags = self.tree.item(current_item, "tags")
+                        if item_tags and item_tags[0].startswith("table_"):
+                            table_id = item_tags[0]
+                        break
+                    current_item = parent_item
+                
+                # Get the node from the IOD model using the path
+                if table_id and table_id in self.iod_models:
+                    model = self.iod_models[table_id]
+                    if model and hasattr(model, 'content') and model.content:
+                        # Find the node by path
+                        try:
+                            # Split the path and traverse to find the node
+                            path_parts = node_path.split("/")
+                            current_node = model.content
+                            
+                            # Navigate through the path (skip the first part which is the root)
+                            for part in path_parts[1:]:  
+                                found = False
+                                for child in current_node.children:
+                                    if str(child.name) == part:
+                                        current_node = child
+                                        found = True
+                                        break
+                                if not found:
+                                    break
+                            else:
+                                # Successfully found the node
+                                node = current_node
+                        except Exception as e:
+                            self.logger.debug(f"Error finding node at path {node_path}: {e}")
+            
+            # Update details text for module/attribute
+
+            if node_type == "Module" and node:
+                # Get all available module attributes
+                name = getattr(node, 'module', 'Unknown Module')
+                usage = getattr(node, 'usage', '')
+                module_ref = getattr(node, 'ref', '')
+                ie = getattr(node, 'ie', '')
+
+                details = f"{name} {node_type}\n\n"
+
+                if ie:
+                    details += f"Information Entity: {ie}\n"
+
+                if usage:
+                    # Format usage as a single line with description and code
+                    if usage.startswith("M"):
+                        usage_display = "Mandatory (M)"
+                    elif usage.startswith("U"):
+                        usage_display = "User Optional (U)"
+                    elif usage.startswith("C"):
+                        # For conditional, include the conditional statement
+                        if len(usage) > 1 and " - " in usage:
+                            conditional_part = usage[usage.find(" - ") + 3:]
+                            usage_display = f"Conditional (C) - {conditional_part}"
+                        else:
+                            usage_display = "Conditional (C)"
+                    else:
+                        usage_display = usage
+                    
+                    details += f"Usage: {usage_display}\n"
+                
+                if module_ref:
+                    details += f"Reference: {module_ref}\n"
+
+            elif node_type == "Attribute" and node:
+                # Get all available attribute details from the node
+                elem_name = getattr(node, 'elem_name', 'Unknown')
+                elem_tag = getattr(node, 'elem_tag', '')
+                elem_type = getattr(node, 'elem_type', '')
+                elem_description = getattr(node, 'elem_description', '')
+                
+                # Display all available attribute information
+                details = f"{elem_name} {node_type}\n\n"
+
+                if elem_tag:
+                    details += f"Tag: {elem_tag}\n"
+                if elem_type:
+                    details += f"Type: {elem_type}\n"
+                if elem_description:
+                    details += f"Description: {elem_description}\n"
+            else:
+                # Fallback for cases without node reference
+                if usage:
+                    details += f"Usage/Type: {usage}\n"
+                
+            self.details_text.delete(1.0, tk.END)
+            self.details_text.insert(1.0, details)
+            
+            self.status_var.set(f"Selected: {node_type} - {title}")
+    
+    def _build_iod_model(self, table_id: str):
+        """Build the IOD model for the given table_id."""
+        url = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
+        cache_file_name = "Part3.xhtml"
+        model_file_name = f"Part3_{table_id}_expanded.json"
+        
+        # Determine if this is a composite or normalized IOD
+        composite_iod = "_A." in table_id
+        
+        # Initialize configuration (using default settings)
+        config = Config(app_name="dcmspec")
+        
+        # Create the IOD specification factory
+        c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
+        n_iod_columns_mapping = {0: "module", 1: "ref", 2: "usage"}
+        iod_columns_mapping = c_iod_columns_mapping if composite_iod else n_iod_columns_mapping
+        iod_factory = SpecFactory(
+            column_to_attr=iod_columns_mapping, 
+            name_attr="module",
+            config=config,
+            logger=self.logger,
+        )
+        
+        # Create the modules specification factory
+        parser_kwargs = None if composite_iod else {"skip_columns": [2]}
+        module_factory = SpecFactory(
+            column_to_attr={0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"},
+            name_attr="elem_name",
+            parser_kwargs=parser_kwargs,
+            config=config,
+            logger=self.logger,
+        )
+        
+        # Create the builder
+        builder = IODSpecBuilder(
+            iod_factory=iod_factory, 
+            module_factory=module_factory,
+            logger=self.logger,
+        )
+        
+        # Build and return the model
+        return builder.build_from_url(
+            url=url,
+            cache_file_name=cache_file_name,
+            json_file_name=model_file_name,
+            table_id=table_id,
+            force_download=False,
+        )
+    
+    def _populate_iod_structure(self, parent_item, content):
+        """Populate the tree with IOD structure from the model content using AnyTree traversal."""
+        if not content:
+            return
+        
+        # Use AnyTree's PreOrderIter to traverse the entire tree structure
+        # Skip the root content node itself, start with its children
+        tree_items = {}  # Map from node to tree item for building hierarchy
+        
+        for node in PreOrderIter(content):
+            if node == content:
+                # Skip the root content node
+                continue
+            
+            # Determine the parent tree item
+            if node.parent == content:
+                # Direct child of content - parent is the IOD item
+                parent_tree_item = parent_item
+            else:
+                # Child of another node - find parent in our mapping
+                parent_tree_item = tree_items.get(node.parent, parent_item)
+            
+            # Determine node type and display text
+            if hasattr(node, 'module'):
+                # This is a module node
+                module_name = getattr(node, 'module', 'Unknown Module')
+                
+                display_text = module_name
+                node_type = "Module"
+                
+                # For normalized IODs, modules don't have usage information
+                # Check if this is a normalized IOD from the parent item's IOD type
+                parent_values = self.tree.item(parent_item, "values") if parent_item else None
+                is_normalized = parent_values and len(parent_values) > 0 and parent_values[0] == "Normalized"
+                
+                if is_normalized:
+                    usage = ""  # No usage for normalized IOD modules
+                else:
+                    usage = getattr(node, 'usage', '')[:1]  # Keep only the first character for composite IODs
+                
+            elif hasattr(node, 'elem_name'):
+                # This is an attribute node
+                attr_name = getattr(node, 'elem_name', 'Unknown Attribute')
+                attr_tag = getattr(node, 'elem_tag', '')
+                elem_type = getattr(node, 'elem_type', '')
+                
+                display_text = f"{attr_tag} {attr_name}" if attr_tag else attr_name
+                
+                node_type = "Attribute"
+                usage = elem_type  # Use elem_type for attributes in usage column
+                
+            else:
+                # Unknown node type
+                display_text = str(getattr(node, 'name', 'Unknown Node'))
+                node_type = "Unknown"
+                usage = ""
+            
+            # Insert the node into the tree, store node path in tags
+            # Node path provides a unique identifier that can be used to find the node later
+            node_path = "/".join([str(n.name) for n in node.path])
+            
+            tree_item = self.tree.insert(
+                parent_tree_item, tk.END, text=display_text, 
+                values=(node_type, usage), tags=(node_path,)
+            )
+            tree_items[node] = tree_item
+    
+    def _update_details_text(self, table_id: str, title: str, iod_type: str):
+        """Update the details text area."""
+        details = f"{title} {iod_type} IOD\n\n"
+        details += f"Table ID: {table_id}"
+        
+        self.details_text.delete(1.0, tk.END)
+        self.details_text.insert(1.0, details)
+        
+        self.status_var.set(f"Selected: {title} {iod_type} IOD)")
+
+
+def main() -> None:
+    """Entry point for the DCMSPEC Explorer GUI application."""
+    root = tk.Tk()
+    DCMSpecExplorer(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dcmspec/apps/dcmspec_explorer/README.md
+++ b/src/dcmspec/apps/dcmspec_explorer/README.md
@@ -4,13 +4,34 @@ A GUI application for exploring DICOM specifications interactively.
 
 ## Running the Application
 
+### Option 1: Using poetry run (recommended)
 ```bash
-# From the project root
-python -m src.dcmspec.apps.dcmspec_explorer
-
-# Or with poetry
-poetry run python -m src.dcmspec.apps.dcmspec_explorer
+poetry run dcmspec-explorer
 ```
+
+### Option 2: Activate environment then run directly
+```bash
+# On Windows PowerShell
+.\.venv\Scripts\Activate.ps1
+dcmspec-explorer
+
+# On Unix/macOS
+source .venv/bin/activate
+dcmspec-explorer
+```
+
+### Option 3: Using the module path
+```bash
+poetry run python -m src.dcmspec.apps.dcmspec_explorer.dcmspec_explorer
+```
+
+### Note on Poetry 2.0+ Environment Activation
+
+If you're using Poetry 2.0+, the `poetry env activate` command only prints the activation command but doesn't actually activate the environment in your current shell. For direct command execution, use one of these approaches:
+
+- **Manual activation (Windows):** `.\.venv\Scripts\Activate.ps1`
+- **Install shell plugin:** `poetry self add poetry-plugin-shell` then use `poetry shell`
+- **Always use `poetry run`:** No activation needed
 
 ## Configuration
 

--- a/src/dcmspec/apps/dcmspec_explorer/README.md
+++ b/src/dcmspec/apps/dcmspec_explorer/README.md
@@ -2,63 +2,16 @@
 
 A GUI application for exploring DICOM specifications interactively.
 
-## Running the Application
+## Documentation
 
-### Option 1: Using poetry run (recommended)
+For complete documentation including installation, configuration, and usage instructions, see:
+
+**[DCMSPEC Explorer Documentation](../../../../docs/apps/dcmspec-explorer.md)**
+
+## Quick Start
+
 ```bash
 poetry run dcmspec-explorer
 ```
 
-### Option 2: Activate environment then run directly
-```bash
-# On Windows PowerShell
-.\.venv\Scripts\Activate.ps1
-dcmspec-explorer
-
-# On Unix/macOS
-source .venv/bin/activate
-dcmspec-explorer
-```
-
-### Option 3: Using the module path
-```bash
-poetry run python -m src.dcmspec.apps.dcmspec_explorer.dcmspec_explorer
-```
-
-### Note on Poetry 2.0+ Environment Activation
-
-If you're using Poetry 2.0+, the `poetry env activate` command only prints the activation command but doesn't actually activate the environment in your current shell. For direct command execution, use one of these approaches:
-
-- **Manual activation (Windows):** `.\.venv\Scripts\Activate.ps1`
-- **Install shell plugin:** `poetry self add poetry-plugin-shell` then use `poetry shell`
-- **Always use `poetry run`:** No activation needed
-
-## Configuration
-
-The application supports customizable configuration through JSON files. Configuration files are searched in the following order:
-
-1. Current directory: `dcmspec_explorer_config.json`
-2. User config: `~/.config/dcmspec/dcmspec_explorer_config.json`
-3. App config directory: `src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config.json`
-4. Legacy location: Same directory as script
-
-For detailed configuration options and examples, see the [config directory](config/README.md).
-
-## Features
-
-- Browse DICOM IODs (Information Object Definitions)
-- Explore IOD modules and attributes hierarchically
-- Sort and filter IOD lists
-- Configurable logging levels
-- Persistent caching of downloaded specifications
-- Context menus for advanced options
-
-## Configuration Examples
-
-The `config/` directory contains several example configurations:
-
-- **Default**: Basic configuration with INFO logging
-- **Debug**: Verbose logging for troubleshooting
-- **Minimal**: Minimal logging for production use
-
-Copy any example to one of the search locations and rename to `dcmspec_explorer_config.json` to use it.
+For more running options and configuration details, refer to the main documentation linked above.

--- a/src/dcmspec/apps/dcmspec_explorer/README.md
+++ b/src/dcmspec/apps/dcmspec_explorer/README.md
@@ -1,0 +1,43 @@
+# DCMSPEC Explorer
+
+A GUI application for exploring DICOM specifications interactively.
+
+## Running the Application
+
+```bash
+# From the project root
+python -m src.dcmspec.apps.dcmspec_explorer
+
+# Or with poetry
+poetry run python -m src.dcmspec.apps.dcmspec_explorer
+```
+
+## Configuration
+
+The application supports customizable configuration through JSON files. Configuration files are searched in the following order:
+
+1. Current directory: `dcmspec_explorer_config.json`
+2. User config: `~/.config/dcmspec/dcmspec_explorer_config.json`
+3. App config directory: `src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config.json`
+4. Legacy location: Same directory as script
+
+For detailed configuration options and examples, see the [config directory](config/README.md).
+
+## Features
+
+- Browse DICOM IODs (Information Object Definitions)
+- Explore IOD modules and attributes hierarchically
+- Sort and filter IOD lists
+- Configurable logging levels
+- Persistent caching of downloaded specifications
+- Context menus for advanced options
+
+## Configuration Examples
+
+The `config/` directory contains several example configurations:
+
+- **Default**: Basic configuration with INFO logging
+- **Debug**: Verbose logging for troubleshooting
+- **Minimal**: Minimal logging for production use
+
+Copy any example to one of the search locations and rename to `dcmspec_explorer_config.json` to use it.

--- a/src/dcmspec/apps/dcmspec_explorer/__init__.py
+++ b/src/dcmspec/apps/dcmspec_explorer/__init__.py
@@ -1,0 +1,9 @@
+"""DCMSPEC Explorer application package.
+
+This package contains the DCMSPEC Explorer GUI application for browsing
+DICOM specifications interactively.
+"""
+
+from .dcmspec_explorer import main, DCMSpecExplorer
+
+__all__ = ['main', 'DCMSpecExplorer']

--- a/src/dcmspec/apps/dcmspec_explorer/config/README.md
+++ b/src/dcmspec/apps/dcmspec_explorer/config/README.md
@@ -1,0 +1,151 @@
+# DCMSPEC Explorer Configuration
+
+This directory contains configuration files and documentation for the DCMSPEC Explorer GUI application.
+
+## Configuration File Search Order
+
+The application searches for configuration files in the following priority order:
+
+### Tier 1: App-Specific Configuration Files
+
+1. `dcmspec_explorer_config.json` in the current directory
+2. `~/.config/dcmspec/dcmspec_explorer_config.json` in the user config directory
+3. `dcmspec_explorer_config.json` in this app config directory (`src/dcmspec/apps/dcmspec_explorer/config/`)
+4. `dcmspec_explorer_config.json` in the same directory as the script (legacy support)
+
+### Tier 2: Base Library Configuration (Fallback)
+
+If no app-specific config is found, the base `Config` class looks for:
+
+- **macOS**: `~/Library/Application Support/dcmspec_explorer/config.json`
+- **Linux**: `~/.config/dcmspec_explorer/config.json`
+- **Windows**: `%USERPROFILE%\AppData\Local\dcmspec_explorer\config.json`
+
+### Default Behavior (No Config Files)
+
+If no configuration files are found anywhere, the application uses:
+
+- **Cache directory**: Platform-specific cache directory (e.g., `~/Library/Caches/dcmspec_explorer`)
+- **Log level**: INFO
+
+## Configuration Options
+
+### `cache_dir`
+
+- **Type**: String
+- **Default**: Platform-specific cache directory (e.g., `~/Library/Caches/dcmspec_explorer` on macOS)
+- **Description**: Directory to store downloaded DICOM specifications and cached models
+
+### `log_level`
+
+- **Type**: String
+- **Default**: "INFO"
+- **Valid values**: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+- **Description**: Sets the logging level for the application
+
+## Configuration Files in This Directory
+
+This directory contains several example configuration files:
+
+- **`dcmspec_explorer_config.json`**: Default configuration with INFO logging
+- **`dcmspec_explorer_config_example.json`**: Basic example configuration
+- **`dcmspec_explorer_config_debug.json`**: Debug configuration with verbose logging
+- **`dcmspec_explorer_config_minimal_logging.json`**: Minimal logging configuration
+
+To use any of these configurations:
+
+1. Copy the desired config file to one of the search locations (see above)
+2. Rename it to `dcmspec_explorer_config.json`
+3. Modify settings as needed
+
+## Example Configuration Files
+
+### Default Configuration
+
+```json
+{
+  "cache_dir": "./cache",
+  "log_level": "INFO"
+}
+```
+
+### Debug Configuration (Verbose Logging)
+
+```json
+{
+  "cache_dir": "/tmp/dcmspec_debug_cache",
+  "log_level": "DEBUG"
+}
+```
+
+### Minimal Logging Configuration
+
+```json
+{
+  "cache_dir": "~/Documents/dcmspec_cache",
+  "log_level": "WARNING"
+}
+```
+
+## Testing Configuration Priority
+
+You can test the configuration search order and see the logging output:
+
+```bash
+cd /path/to/dcmspec
+
+# Test with app-specific config (Tier 1)
+echo '{"cache_dir": "./app_cache", "log_level": "INFO"}' > dcmspec_explorer_config.json
+/path/to/python -c "
+from src.dcmspec.apps.dcmspec_explorer import load_app_config, setup_logger
+config = load_app_config()
+logger = setup_logger(config)
+logger.info('Starting DCMSPEC Explorer')
+log_level = config.get_param('log_level') or 'INFO'
+source = 'app-specific' if 'dcmspec_explorer_config.json' in (config.config_file or '') else 'default'
+logger.info(f'Logging configured: level={log_level.upper()}, source={source}')
+logger.info(f'Config file: {config.config_file or \"none (using defaults)\"}')
+logger.info(f'Cache directory: {config.cache_dir}')
+"
+
+# Expected output:
+# INFO - Starting DCMSPEC Explorer
+# INFO - Logging configured: level=INFO, source=app-specific
+# INFO - Config file: dcmspec_explorer_config.json
+# INFO - Cache directory: ./app_cache
+```
+
+The application will display important configuration information at startup, including:
+
+- **Log level and source**: Whether config comes from app-specific file or defaults
+- **Config file location**: Exact path to the configuration file being used
+- **Cache directory**: Where downloaded specifications and models are stored
+
+This information helps with troubleshooting and understanding the application's configuration.
+
+## Usage
+
+You can test your configuration without running the full GUI:
+
+```bash
+cd /path/to/dcmspec
+/path/to/python -c "
+from src.dcmspec.apps.dcmspec_explorer import load_app_config, setup_logger
+config = load_app_config()
+logger = setup_logger(config)
+print(f'Config file: {config.config_file}')
+print(f'Cache dir: {config.cache_dir}')
+print(f'Log level: {config.get_param(\"log_level\")}')
+logger.info('Test log message')
+logger.debug('Debug message')
+"
+```
+
+## Usage
+
+1. Copy one of the example configuration files to one of the supported locations
+2. Rename it to `dcmspec_explorer_config.json`
+3. Modify the settings as needed
+4. Start the DCMSPEC Explorer application
+
+The application will automatically detect and use the configuration file. You'll see log messages indicating which configuration file was loaded and the current settings.

--- a/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config.json
+++ b/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config.json
@@ -1,0 +1,4 @@
+{
+  "cache_dir": "./cache",
+  "log_level": "INFO"
+}

--- a/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_debug.json
+++ b/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_debug.json
@@ -1,0 +1,4 @@
+{
+  "cache_dir": "/tmp/dcmspec_debug_cache",
+  "log_level": "DEBUG"
+}

--- a/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_example.json
+++ b/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_example.json
@@ -1,0 +1,4 @@
+{
+  "cache_dir": "./cache",
+  "log_level": "INFO"
+}

--- a/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_minimal_logging.json
+++ b/src/dcmspec/apps/dcmspec_explorer/config/dcmspec_explorer_config_minimal_logging.json
@@ -1,0 +1,4 @@
+{
+  "cache_dir": "~/Documents/dcmspec_cache",
+  "log_level": "WARNING"
+}

--- a/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
+++ b/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
@@ -663,9 +663,6 @@ class DCMSpecExplorer:
         # Determine if this is a composite or normalized IOD
         composite_iod = "_A." in table_id
         
-        # Initialize configuration (using default settings)
-        config = Config(app_name="dcmspec")
-        
         # Create the IOD specification factory
         c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
         n_iod_columns_mapping = {0: "module", 1: "ref", 2: "usage"}
@@ -673,7 +670,7 @@ class DCMSpecExplorer:
         iod_factory = SpecFactory(
             column_to_attr=iod_columns_mapping, 
             name_attr="module",
-            config=config,
+            config=self.config,
             logger=self.logger,
         )
         
@@ -683,7 +680,7 @@ class DCMSpecExplorer:
             column_to_attr={0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_description"},
             name_attr="elem_name",
             parser_kwargs=parser_kwargs,
-            config=config,
+            config=self.config,
             logger=self.logger,
         )
         

--- a/src/dcmspec/cli/iodattributes.py
+++ b/src/dcmspec/cli/iodattributes.py
@@ -42,12 +42,12 @@ def main():
         poetry run python -m src.dcmspec.cli.iodattributes <table_id> [options]
 
     Options:
-        table (str): Table ID to extract (e.g., "table_A.1-1" or "table_B.1-1").
+        table (str): Table ID to extract (e.g., "table_A.3-1" or "table_B.26.2-1").
         --config (str): Path to the configuration file.
         --print-mode (str): Print as 'table' (default), 'tree', or 'none' to skip printing.
 
     Example:
-        poetry run python -m src.dcmspec.cli.iodattributes table_A.1-1 --print-mode tree
+        poetry run python -m src.dcmspec.cli.iodattributes table_A.3-1 --print-mode tree
 
     """
     url = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"


### PR DESCRIPTION
DCMSpec Explorer: Interactive DICOM IOD Browser
- Uses Tkinter GUI
- Loads DICOM Part 3 Table of Contents (TOC)
- Extracts Part 3 list of tables from TOC
- Creates a TreeView for IOD tables with IOD type (Composite/Normalized)
- Parses Part 3 table on TreeView item selection
- Provides sorting by IOD name and type
- Provides searching by name and type
- Provides persistent favorites management
- Provides toggling between "All IODs" and favorites view

## Summary by Sourcery

Add a new DCMSPEC Explorer GUI application for interactive browsing of DICOM IODs and improve table parsing utilities

New Features:
- Introduce a Tkinter-based DCMSPEC Explorer app with sortable, searchable IOD tree view and persistent favorites
- Register a new dcmspec-explorer entrypoint and additional CLI scripts in pyproject.toml

Enhancements:
- Enhance DOMTableSpecParser to detect circular references and clean extracted text artifacts
- Update iodattributes CLI examples to use correct table ID patterns

Build:
- Add new CLI script entries in pyproject.toml for dcmspec-explorer and related commands

Documentation:
- Add MkDocs navigation, README, and detailed docs for the DCMSPEC Explorer application and its configuration