### PR TITLE
Add option to DOMTableSpecParser to preserve HTML

### DIFF
--- a/docs/apps/dcmspec-explorer.md
+++ b/docs/apps/dcmspec-explorer.md
@@ -2,14 +2,65 @@
 
 A GUI application for exploring DICOM specifications interactively.
 
+## Dependencies
+
+- **tkhtmlview** (required for the GUI, but now installed only if you request the GUI extra)
+- **tkinter** (required for the GUI, but not installed via pip or Poetry)
+
+> **Note:**  
+> `tkinter` is part of the Python standard library, but on some Linux distributions and on macOS with Homebrew Python, it must be installed separately.
+>
+> - On **Ubuntu/Debian**: `sudo apt install python3-tk`
+> - On **Fedora**: `sudo dnf install python3-tkinter`
+> - On **macOS (Homebrew Python)**: `brew install tcl-tk`
+>   - You may also need to set environment variables so Python can find the Tk libraries. See [Homebrew Python and Tkinter](https://docs.brew.sh/Homebrew-and-Python#tkinter) for details.
+> - On **Windows/macOS (python.org installer)**: Usually included with the official Python installer.
+>
+> If you get an error about `tkinter` not being found, please install it as shown above.
+
+## Installation
+
+Clone the repository and install dependencies with Poetry:
+
+```bash
+git clone https://github.com/yourusername/dcmspec.git
+cd dcmspec
+poetry install --with gui
+```
+
+Or, with pip (from the repo root):
+
+```bash
+pip install .[gui]
+```
+
+This installs the package and its dependencies from your local source directory, including the GUI dependencies.  
+If you want to make changes to the code and have them reflected immediately, use:
+
+```bash
+pip install -e .[gui]
+```
+
+> **Tip:**  
+> It is recommended to use a virtual environment (venv) before running `pip install .[gui]` to avoid installing packages globally.  
+> Poetry manages a venv automatically, but if you use pip directly, create one with:
+>
+> ```bash
+> python -m venv .venv
+> source .venv/bin/activate  # On Unix/macOS
+> .\.venv\Scripts\Activate.ps1  # On Windows PowerShell
+> ```
+
 ## Running the Application
 
 ### Option 1: Using poetry run (recommended)
+
 ```bash
 poetry run dcmspec-explorer
 ```
 
 ### Option 2: Activate environment then run directly
+
 ```bash
 # On Windows PowerShell
 .\.venv\Scripts\Activate.ps1
@@ -21,6 +72,7 @@ dcmspec-explorer
 ```
 
 ### Option 3: Using the module path
+
 ```bash
 poetry run python -m src.dcmspec.apps.dcmspec_explorer.dcmspec_explorer
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,49 @@
 
 ---
 
+## For Users of the GUI Application
+
+- Install the package with the GUI extra (installs `tkhtmlview`):
+
+  ```bash
+  pip install "git+https://github.com/dwikler/dcmspec.git@v0.1.0#egg=dcmspec[gui]"
+  ```
+
+  Or, with Poetry:
+
+  ```bash
+  git clone https://github.com/dwikler/dcmspec.git
+  cd dcmspec
+  poetry install --with gui
+  ```
+
+- **tkinter** is also required for the GUI, but is not installed via pip or Poetry.
+
+  > **Note:**  
+  > `tkinter` is part of the Python standard library, but on some Linux distributions and on macOS with Homebrew Python, it must be installed separately.
+  >
+  > - On **Ubuntu/Debian**: `sudo apt install python3-tk`
+  > - On **Fedora**: `sudo dnf install python3-tkinter`
+  > - On **macOS (Homebrew Python)**: `brew install tcl-tk`
+  >   - You may also need to set environment variables so Python can find the Tk libraries. See [Homebrew Python and Tkinter](https://docs.brew.sh/Homebrew-and-Python#tkinter) for details.
+  > - On **Windows/macOS (python.org installer)**: Usually included with the official Python installer.
+  >
+  > If you get an error about `tkinter` not being found, please install it as shown above.
+
+- Run the GUI application:
+
+  ```bash
+  poetry run dcmspec-explorer
+  ```
+
+  Or, after activating your environment:
+
+  ```bash
+  dcmspec-explorer
+  ```
+
+---
+
 ## For Developers Using the API
 
 - Add the following to your `pyproject.toml` (for Poetry-based projects):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "David Wikler",email = "david.wikler@ulb.ac.be"}
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "anytree (>=2.13.0,<3.0.0) ; python_version >= \"3.12\" and python_version < \"4.0\"",
     "platformdirs (>=4.3.8,<5.0.0)",
@@ -18,6 +18,9 @@ dependencies = [
     "pdfplumber (>=0.11.7,<0.12.0)",
     "camelot-py (>=1.0.0,<2.0.0)",
 ]
+
+[project.optional-dependencies]
+gui = ["tkhtmlview (>=0.3.1,<0.4.0)"]
 
 [tool.poetry]
 packages = [{include = "dcmspec", from = "src"}]

--- a/src/dcmspec/apps/dcmspec_explorer/README.md
+++ b/src/dcmspec/apps/dcmspec_explorer/README.md
@@ -15,3 +15,19 @@ poetry run dcmspec-explorer
 ```
 
 For more running options and configuration details, refer to the main documentation linked above.
+
+## Dependencies
+
+- **tkhtmlview** (installed automatically with Poetry)
+- **tkinter** (required for the GUI, but not installed via pip or Poetry)
+
+> **Note:**  
+> `tkinter` is part of the Python standard library, but on some Linux distributions and on macOS with Homebrew Python, it must be installed separately.
+>
+> - On **Ubuntu/Debian**: `sudo apt install python3-tk`
+> - On **Fedora**: `sudo dnf install python3-tkinter`
+> - On **macOS (Homebrew Python)**: `brew install tcl-tk`
+>   - You may also need to set environment variables so Python can find the Tk libraries. See [Homebrew Python and Tkinter](https://docs.brew.sh/Homebrew-and-Python#tkinter) for details.
+> - On **Windows/macOS (python.org installer)**: Usually included with the official Python installer.
+>
+> If you get an error about `tkinter` not being found, please install it as shown above.

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -9,7 +9,7 @@ import unicodedata
 from unidecode import unidecode
 from anytree import Node
 from bs4 import BeautifulSoup, Tag
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from dcmspec.spec_parser import SpecParser
 from dcmspec.dom_utils import DOMUtils
 
@@ -42,7 +42,7 @@ class DOMTableSpecParser(SpecParser):
         name_attr: str,
         include_depth: Optional[int] = None,  # None means unlimited
         skip_columns: Optional[list[int]] = None,
-        unformatted: Optional[Any] = True,  # bool or dict
+        unformatted: Optional[Union[bool, Dict[int, bool]]] = True,
     ) -> tuple[Node, Node]:
         """Parse specification metadata and content from tables in the DOM.
 

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -64,7 +64,7 @@ class SpecFactory:
             logger (Optional[logging.Logger]): Logger instance to use.
                 If None, a default logger is created.
             parser_kwargs (Optional[Dict[str, Any]]): Default keyword arguments to pass to the parser's
-                `parse` method. Use this to supply parser-specific options such as `skip_columns`.
+                `parse` method. Use this to supply parser-specific options such as `skip_columns` or `unformatted`.
 
         Raises:
             TypeError: If config is not a Config instance or None.

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -39,6 +39,53 @@ def test_parse_table_returns_node(docbook_sample_dom_1):  # noqa: F811
     assert children[1].elem_type == "2"
     assert children[1].elem_desc == "Desc2"
 
+def test_parse_table_unformatted_false_returns_html(docbook_sample_dom_1):  # noqa: F811
+    """Test that setting unformatted_list with False for a column returns the HTML for that column."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
+    # Set unformatted_list so that column 3 (elem_desc) returns HTML, others return text
+    unformatted_list = [True, True, True, False]
+    node = parser.parse_table(
+        dom=docbook_sample_dom_1,
+        table_id="table_SAMPLE",
+        column_to_attr=column_to_attr,
+        name_attr="elem_name",
+        unformatted_list=unformatted_list
+    )
+    children = list(node.children)
+    assert len(children) == 2
+    # elem_name should be plain text
+    assert children[0].elem_name == "Attr Name (Tést)"
+    # elem_desc should be the exact HTML for the cell
+    expected_html = '<p>Desc1</p>'
+    assert children[0].elem_desc.strip() == expected_html
+    expected_html2 = '<p>Desc2</p>'
+    assert children[1].elem_desc.strip() == expected_html2
+
+def test_parse_table_warns_and_forces_unformatted_true_for_name_attr(docbook_sample_dom_1, caplog):  # noqa: F811
+    """Test that parse_table forces unformatted=True for the name_attr column and logs a warning if set to False."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
+    # Set unformatted_list so that column 0 (elem_name, the name_attr) is False, others are True
+    unformatted_list = [False, True, True, True]
+    with caplog.at_level("WARNING"):
+        node = parser.parse_table(
+            dom=docbook_sample_dom_1,
+            table_id="table_SAMPLE",
+            column_to_attr=column_to_attr,
+            name_attr="elem_name",
+            unformatted_list=unformatted_list
+        )
+    children = list(node.children)
+    # elem_name should still be plain text, not HTML
+    assert children[0].elem_name == "Attr Name (Tést)"
+    assert children[1].elem_name == "AttrName2"
+    # There should be a warning in the logs
+    assert any(
+        "unformatted=False for name_attr column 'elem_name'" in record.message
+        for record in caplog.records
+    )
+
 @pytest.mark.parametrize(
     "fixture_name, expected_version",
     [
@@ -331,6 +378,39 @@ def test_parse_table_include_with_gt_nests_under_previous(table_include_dom):  #
     assert len(included_children) == 2
     assert included_children[0].col1 == ">AttrName10"
     assert included_children[1].col1 == ">AttrName11"
+
+def test_parse_table_include_with_gt_nests_under_previous_html_elem_desc(table_include_dom):  # noqa: F811
+    """Test parsing nested structures with unformatted_list is set to False for column 3."""
+    # Modify the fixture to use '>Include' instead of 'Include'
+    html = str(table_include_dom)
+    html = html.replace("Include <a", "&gt;Include <a")
+    dom = BeautifulSoup(html, "lxml-xml")
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3", 3: "elem_desc"}
+    # Set unformatted_list so that column 3 (elem_desc) returns HTML, others return text
+    unformatted_list = [True, True, True, False]
+    node = parser.parse_table(
+        dom=dom,
+        table_id="table_MAIN",
+        column_to_attr=column_to_attr,
+        name_attr="col1",
+        unformatted_list=unformatted_list
+    )
+    children = list(node.children)
+    # The root should have 2 children: AttrName1 and AttrName2 and both should have elem_desc as HTML
+    assert len(children) == 2
+    assert children[0].col1 == "AttrName1"
+    assert children[1].col1 == "AttrName2"
+    # The included table rows should be children of AttrName2
+    included_children = list(children[1].children)
+    assert len(included_children) == 2
+    assert included_children[0].col1 == ">AttrName10"
+    assert included_children[1].col1 == ">AttrName11"
+    # Both levels should have the exact HTML for elem_desc
+    assert children[0].elem_desc.strip() == "<p>Desc1</p>"
+    assert children[1].elem_desc.strip() == "<p>Desc2</p>"
+    assert included_children[0].elem_desc.strip() == "<p>Bla</p>"
+    assert included_children[1].elem_desc.strip() == "<p>Bla</p>"
 
 def test_parse_table_include_missing_table(table_include_dom):  # noqa: F811
     """Test that parse_table raises ValueError when an 'Include' row references a non-existent table."""

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -334,7 +334,6 @@ def test_parse_table_colspan_rowspan(table_colspan_rowspan_dom):  # noqa: F811
     assert children[1].col1 == "A"  # from rowspan+colspan
     assert children[1].col3 == "C"
 
-
 def test_parse_table_include_triggers_recursion(table_include_dom):  # noqa: F811
     """Test that parse_table handles an 'Include' row and recursively parses the included table."""
     parser = DOMTableSpecParser()


### PR DESCRIPTION
- Update DOMTableSpecParser to support `unformatted` arg for cell HTML extraction
- Render dcmspec_explorer details pane as HTML using tkhtmlview
- Change dcmspec_explorer treeview pane headings Update documentation

## Summary by Sourcery

Support optional unformatted HTML extraction in table parser, update the explorer UI to display HTML details with tkhtmlview, and extend documentation and tests for the new GUI HTML rendering option

New Features:
- Add unformatted argument to DOMTableSpecParser to optionally preserve cell HTML content
- Enable rendering HTML content in the DCMspec Explorer details pane via tkhtmlview
- Expose the unformatted option through SpecFactory parser_kwargs
- Introduce a "gui" optional dependency for HTML rendering in pyproject.toml

Enhancements:
- Refactor DOMTableSpecParser to extract row processing and circular-reference checks into helper methods
- Rename treeview columns from "IOD Name"/"IOD Type" to "Name"/"Kind" and unify detail text handling in the explorer
- Adjust requires-python constraint to <4.0

Documentation:
- Document tkhtmlview and tkinter installation steps in explorer and installation guides
- Add instructions for installing the GUI extra in project documentation

Tests:
- Add tests for unformatted flag behavior in DOMTableSpecParser, verifying HTML extraction and warning enforcement