### PR TITLE
refactor and document optional dependencies for lightweight install

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,4 +118,64 @@
   # ... your code here ...
   ```
 
+---
+
+## Dependencies and Optional Features
+
+### Core Dependencies
+
+The core `dcmspec` library is designed to be lightweight and only requires a minimal set of dependencies for parsing and working with DICOM specification tables in HTML/XHTML format.
+
+Core dependencies include:
+
+- anytree
+- platformdirs
+- unidecode
+- bs4 (BeautifulSoup)
+- requests
+- lxml
+- rich
+
+These are sufficient for most use cases, including all parsing and tree-building from DICOM standard HTML/XHTML documents.
+
+### Optional PDF/Table Extraction Dependencies
+
+Some features, such as extracting tables directly from PDF files, require additional heavy dependencies. These are **not installed by default** and are grouped under the `pdf` optional dependency.
+
+To install with PDF/table extraction support:
+
+```
+poetry add "dcmspec[pdf]"@git+https://github.com/dwikler/dcmspec.git
+```
+
+Optional dependencies for PDF/table extraction:
+
+- pdfplumber
+- camelot-py
+- pandas
+- openpyxl
+- opencv-python-headless
+
+These are only needed if you want to extract tables from PDF documents.
+
+### GUI Dependencies
+
+If you want to use the sample GUI explorer app, you can install the `gui` extra:
+
+```
+poetry add "dcmspec[gui]"@git+https://github.com/dwikler/dcmspec.git
+```
+
+This will install:
+
+- tkhtmlview
+
+### Summary
+
+- Default install: Lightweight, core parsing features only.
+- With `[pdf]` extra: Adds PDF/table extraction support.
+- With `[gui]` extra: Adds GUI dependencies for the sample explorer app.
+
+See the pyproject.toml for the full list of dependencies and extras.
+
 See the [API Reference](./api/index.md) for details on available classes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+pdf = [
+    "pdfplumber (>=0.11.7,<0.12.0)",
+    "camelot-py (>=1.0.0,<2.0.0)",
+    "pandas (>=2.3.1,<3.0.0)",
+    "openpyxl (>=3.1.5,<4.0.0)",
+    "opencv-python-headless (>=4.12.0.88,<5.0.0)",
+]
 gui = ["tkhtmlview (>=0.3.1,<0.4.0)"]
 
 [tool.poetry]


### PR DESCRIPTION
- Move heavy PDF/table extraction dependencies to [project.optional-dependencies] in pyproject.toml
- Update installation.md to clearly explain core, [pdf], and [gui] extras and their installation