### PR TITLE
Add progress reporting for DocHandler download

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,6 +138,11 @@ Core dependencies include:
 
 These are sufficient for most use cases, including all parsing and tree-building from DICOM standard HTML/XHTML documents.
 
+> **Note on lxml:**  
+> `lxml` is a core dependency for fast and robust XML/HTML parsing. It is not a pure Python package, but pre-built wheels are available for most platforms.  
+> On some Linux systems, you may need to install system packages (e.g., `libxml2-dev`, `libxslt-dev`, and `python3-dev`) before installing `lxml`.  
+> See the [lxml installation docs](https://lxml.de/installation.html) for details.
+
 ### Optional PDF/Table Extraction Dependencies
 
 Some features, such as extracting tables directly from PDF files, require additional heavy dependencies. These are **not installed by default** and are grouped under the `pdf` optional dependency.

--- a/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
+++ b/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
@@ -884,8 +884,14 @@ class DCMSpecExplorer:
         self._last_progress_percent = -1  # Add this line before defining the callback
 
         def progress_callback(percent):
-            # Only update every 10% and only if the percent changed
-            if (percent % 10 == 0 or percent == 100) and percent != self._last_progress_percent:
+            # Update the status bar with the current download progress
+            if percent == -1:
+                # Indeterminate progress
+                self.status_var.set("Downloading IOD modules... (progress unknown)")
+                self.root.update()
+                self._last_progress_percent = percent
+            elif (percent % 10 == 0 or percent == 100) and percent != self._last_progress_percent:
+                # Update every 10% and only if the percent changedÒ
                 self.status_var.set(f"Downloading IOD modules... {percent}%")
                 self.root.update()
                 self._last_progress_percent = percent

--- a/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
+++ b/src/dcmspec/apps/dcmspec_explorer/dcmspec_explorer.py
@@ -873,50 +873,60 @@ class DCMSpecExplorer:
 
     def load_iod_modules(self, force_download: bool = False):
         """Load IOD modules from the DICOM specification.
-        
+
         Args:
             force_download (bool): If True, force download from URL instead of using cache.
-            
+
         """
         self.status_var.set("Loading IOD modules...")
         self.root.update()
-        
+
+        self._last_progress_percent = -1  # Add this line before defining the callback
+
+        def progress_callback(percent):
+            # Only update every 10% and only if the percent changed
+            if (percent % 10 == 0 or percent == 100) and percent != self._last_progress_percent:
+                self.status_var.set(f"Downloading IOD modules... {percent}%")
+                self.root.update()
+                self._last_progress_percent = percent
+
         try:
             # Clear existing items
             for item in self.tree.get_children():
                 self.tree.delete(item)
-            
+
             # Use XHTMLDocHandler to download and parse the HTML with caching
             cache_file_name = "ps3.3.html"
             soup = self.doc_handler.load_document(
                 cache_file_name=cache_file_name,
                 url=self.part3_toc_url,
-                force_download=force_download
+                force_download=force_download,
+                progress_callback=progress_callback
             )
-            
+
             # Extract and display DICOM version using the library method
             self.dicom_version = self.dom_parser.get_version(soup, "")
             self.version_label.config(text=f"Version {self.dicom_version}")
-            
+
             # Find the list of tables div
             list_of_tables = soup.find('div', class_='list-of-tables')
             if not list_of_tables:
                 messagebox.showerror("Error", "Could not find list-of-tables section")
                 return
-            
+
             # Extract IOD modules
             iod_modules = self.extract_iod_modules(list_of_tables)
-            
+
             # Store the data for sorting and filtering
             self.iod_modules_data = iod_modules
-            
+
             # Set initial sort state to show that data is sorted by IOD Name
             self.sort_column = "#0"
             self.sort_reverse = False
-            
+
             # Apply filter and sort (this will populate the treeview)
             self.apply_filter_and_sort()
-            
+
             # Set initial view mode based on whether we have favorites
             if self.favorites_manager.get_favorites_count() > 0 and not self.show_favorites_only:
                 # If we have favorites and haven't explicitly chosen a view, show favorites
@@ -924,15 +934,15 @@ class DCMSpecExplorer:
             else:
                 # Otherwise show all (which is the current state)
                 self.set_view_mode(False)
-            
+
             # Update column headings to show initial sort state
             self.update_column_headings()
-            
+
             # Add cache status to the current status (after apply_filter_and_sort sets it)
             cache_status = " (downloaded)" if force_download else " (from cache)"
             current_status = self.status_var.get()
             self.status_var.set(f"{current_status}{cache_status}")
-            
+
         except RuntimeError as e:
             messagebox.showerror("Error", f"Failed to load DICOM specification:\n{str(e)}")
             self.status_var.set("Error loading modules")

--- a/src/dcmspec/doc_handler.py
+++ b/src/dcmspec/doc_handler.py
@@ -8,6 +8,7 @@ Subclasses should implement the `load_document` method for their specific format
 import os
 from typing import Any, Optional
 import logging
+import requests
 
 from dcmspec.config import Config
 
@@ -43,7 +44,7 @@ class DocHandler:
             raise TypeError("config must be an instance of Config or None")
         self.config = config or Config()
 
-    def download(self, url: str, file_path: str, binary: bool = False) -> str:
+    def download(self, url: str, file_path: str, binary: bool = False, progress_callback=None) -> str:
         """Download a file from a URL and save it to the specified path.
 
         Downloads a file from the given URL and saves it to the specified file path.
@@ -54,6 +55,7 @@ class DocHandler:
             url (str): The URL to download the file from.
             file_path (str): The path to save the downloaded file.
             binary (bool): If True, save as binary. If False, save as UTF-8 text.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
 
         Returns:
             str: The file path where the document was saved.
@@ -62,7 +64,6 @@ class DocHandler:
             RuntimeError: If the download or save fails.
 
         """
-        import requests
         self.logger.info(f"Downloading document from {url} to {file_path}")
         try:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
@@ -70,16 +71,14 @@ class DocHandler:
             self.logger.error(f"Failed to create directory for {file_path}: {e}")
             raise RuntimeError(f"Failed to create directory for {file_path}: {e}") from e
         try:
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-            if binary:
-                with open(file_path, "wb") as f:
-                    f.write(response.content)
-            else:
-                content = response.text
-                content = self.clean_text(content)
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(content)
+            with requests.get(url, timeout=30, stream=True, headers={"Accept-Encoding": "identity"}) as response:
+                response.raise_for_status()
+                total = int(response.headers.get('content-length', 0))
+                chunk_size = 8192
+                if binary:
+                    self._download_binary(response, file_path, total, chunk_size, progress_callback)
+                else:
+                    self._download_text(response, file_path, total, chunk_size, progress_callback)
             self.logger.info(f"Document downloaded to {file_path}")
             return file_path
         except requests.exceptions.RequestException as e:
@@ -88,6 +87,40 @@ class DocHandler:
         except OSError as e:
             self.logger.error(f"Failed to save file {file_path}: {e}")
             raise RuntimeError(f"Failed to save file {file_path}: {e}") from e
+
+    def _download_binary(self, response, file_path, total, chunk_size, progress_callback):
+        """Download and save a binary file with progress reporting."""
+        downloaded = 0
+        last_percent = -1
+        with open(file_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if progress_callback and total:
+                        percent = min(int(downloaded * 100 / total), 100)
+                        if percent != last_percent:
+                            progress_callback(percent)
+                            last_percent = percent
+
+    def _download_text(self, response, file_path, total, chunk_size, progress_callback):
+        """Download and save a text file with progress reporting."""
+        content = []
+        downloaded = 0
+        last_percent = -1
+        for chunk in response.iter_content(chunk_size=chunk_size, decode_unicode=True):
+            if chunk:
+                content.append(chunk)
+                chunk_bytes = chunk.encode('utf-8')
+                downloaded += len(chunk_bytes)
+                if progress_callback and total:
+                    percent = min(int(downloaded * 100 / total), 100)
+                    if percent != last_percent:
+                        progress_callback(percent)
+                        last_percent = percent
+        content_str = self.clean_text("".join(content))
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(content_str)
 
     def clean_text(self, text: str) -> str:
         """Clean text content before saving.
@@ -109,6 +142,7 @@ class DocHandler:
         cache_file_name: str,
         url: Optional[str] = None,
         force_download: bool = False,
+        progress_callback=None,
         *args: Any,
         **kwargs: Any
     ) -> Any:
@@ -123,6 +157,7 @@ class DocHandler:
             cache_file_name (str): Path or name of the local cached file.
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool, optional): If True, download the file even if it exists locally.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
             *args: Additional positional arguments for format-specific loading.
             **kwargs: Additional keyword arguments for format-specific loading.
 

--- a/src/dcmspec/doc_handler.py
+++ b/src/dcmspec/doc_handler.py
@@ -6,7 +6,7 @@ method for both text and binary files, and defines the interface for document pa
 Subclasses should implement the `load_document` method for their specific format.
 """
 import os
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 import logging
 import requests
 
@@ -44,7 +44,13 @@ class DocHandler:
             raise TypeError("config must be an instance of Config or None")
         self.config = config or Config()
 
-    def download(self, url: str, file_path: str, binary: bool = False, progress_callback=None) -> str:
+    def download(
+        self,
+        url: str,
+        file_path: str,
+        binary: bool = False,
+        progress_callback: 'Optional[Callable[[int], None]]' = None
+    ) -> str:        
         """Download a file from a URL and save it to the specified path.
 
         Downloads a file from the given URL and saves it to the specified file path.
@@ -56,6 +62,8 @@ class DocHandler:
             file_path (str): The path to save the downloaded file.
             binary (bool): If True, save as binary. If False, save as UTF-8 text.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
 
         Returns:
             str: The file path where the document was saved.
@@ -88,36 +96,51 @@ class DocHandler:
             self.logger.error(f"Failed to save file {file_path}: {e}")
             raise RuntimeError(f"Failed to save file {file_path}: {e}") from e
 
+    def _report_progress(self, downloaded, total, progress_callback, last_percent):
+        """Report progress if percent changed.
+
+        If the total file size is unknown or invalid, calls the callback with -1 to indicate
+        indeterminate progress. Otherwise, calls the callback with the integer percent (0-100).
+        """
+        if not progress_callback:
+            return
+        if not total or total <= 0:
+            # Unknown total size: show indeterminate progress (use -1 as a sentinel)
+            if last_percent[0] != -1:
+                progress_callback(-1)
+                last_percent[0] = -1
+            return
+        percent = min(int(downloaded * 100 / total), 100)
+        if percent != last_percent[0]:
+            progress_callback(percent)
+            last_percent[0] = percent
+
     def _download_binary(self, response, file_path, total, chunk_size, progress_callback):
         """Download and save a binary file with progress reporting."""
         downloaded = 0
-        last_percent = -1
+        last_percent = [None]
         with open(file_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)
                     downloaded += len(chunk)
-                    if progress_callback and total:
-                        percent = min(int(downloaded * 100 / total), 100)
-                        if percent != last_percent:
-                            progress_callback(percent)
-                            last_percent = percent
+                    self._report_progress(downloaded, total, progress_callback, last_percent)
 
     def _download_text(self, response, file_path, total, chunk_size, progress_callback):
-        """Download and save a text file with progress reporting."""
+        """Download and save a text file with progress reporting.
+
+        Uses response.encoding if available for accurate byte counting and file writing.
+        """
         content = []
         downloaded = 0
-        last_percent = -1
+        last_percent = [None]
+        encoding = response.encoding or "utf-8"
         for chunk in response.iter_content(chunk_size=chunk_size, decode_unicode=True):
             if chunk:
                 content.append(chunk)
-                chunk_bytes = chunk.encode('utf-8')
+                chunk_bytes = chunk.encode(encoding)
                 downloaded += len(chunk_bytes)
-                if progress_callback and total:
-                    percent = min(int(downloaded * 100 / total), 100)
-                    if percent != last_percent:
-                        progress_callback(percent)
-                        last_percent = percent
+                self._report_progress(downloaded, total, progress_callback, last_percent)
         content_str = self.clean_text("".join(content))
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(content_str)
@@ -142,7 +165,7 @@ class DocHandler:
         cache_file_name: str,
         url: Optional[str] = None,
         force_download: bool = False,
-        progress_callback=None,
+        progress_callback: 'Optional[Callable[[int], None]]' = None,
         *args: Any,
         **kwargs: Any
     ) -> Any:
@@ -158,6 +181,8 @@ class DocHandler:
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool, optional): If True, download the file even if it exists locally.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
             *args: Additional positional arguments for format-specific loading.
             **kwargs: Additional keyword arguments for format-specific loading.
 

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -50,6 +50,7 @@ class IODSpecBuilder:
         cache_file_name: str,
         table_id: str,
         force_download: bool = False,
+        progress_callback=None,
         json_file_name: str = None,
         **kwargs: object,
     ) -> SpecModel:
@@ -68,6 +69,7 @@ class IODSpecBuilder:
             cache_file_name (str): Filename of the cached input file.
             table_id (str): The ID of the IOD table to parse.
             force_download (bool): If True, always download the input file and generate the model even if cached.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
             json_file_name (str, optional): Filename to save the cached expanded JSON model.
             **kwargs: Additional arguments for model construction.
 
@@ -86,6 +88,7 @@ class IODSpecBuilder:
             url=url,
             cache_file_name=cache_file_name,
             force_download=force_download,
+            progress_callback=progress_callback,
         )
 
         # Build the IOD Modules model from the DOM

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -5,6 +5,7 @@ DICOM IOD model, combining the IOD Modules and Module Attributes models.
 """
 import logging
 import os
+from typing import Callable, Optional
 
 from anytree import Node
 from dcmspec.dom_utils import DOMUtils
@@ -50,7 +51,7 @@ class IODSpecBuilder:
         cache_file_name: str,
         table_id: str,
         force_download: bool = False,
-        progress_callback=None,
+        progress_callback: 'Optional[Callable[[int], None]]' =None,
         json_file_name: str = None,
         **kwargs: object,
     ) -> SpecModel:
@@ -70,6 +71,8 @@ class IODSpecBuilder:
             table_id (str): The ID of the IOD table to parse.
             force_download (bool): If True, always download the input file and generate the model even if cached.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
             json_file_name (str, optional): Filename to save the cached expanded JSON model.
             **kwargs: Additional arguments for model construction.
 

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -6,7 +6,7 @@ from IHE Technical Frameworks or Supplements, returning CSV data from tables in 
 
 import os
 import logging
-from typing import Optional, List
+from typing import Callable, Optional, List
 
 import pdfplumber
 import camelot
@@ -52,6 +52,7 @@ class PDFDocHandler(DocHandler):
         cache_file_name: str,
         url: Optional[str] = None,
         force_download: bool = False,
+        progress_callback: Optional[Callable[[int], None]] = None,
         page_numbers: Optional[list] = None,
         table_indices: Optional[list] = None,
         table_header_rowspan: Optional[dict] = None,
@@ -63,6 +64,7 @@ class PDFDocHandler(DocHandler):
             cache_file_name (str): Path to the local cached PDF file.
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool): If True, do not use cache and download the file from the URL.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
             page_numbers (list, optional): List of page numbers to extract tables from.
             table_indices (list, optional): List of (page, index) tuples specifying which tables to concatenate.
             table_header_rowspan (dict, optional): Number of header rows (rowspan) for each table in table_indices.

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -65,6 +65,8 @@ class PDFDocHandler(DocHandler):
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool): If True, do not use cache and download the file from the URL.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
             page_numbers (list, optional): List of page numbers to extract tables from.
             table_indices (list, optional): List of (page, index) tuples specifying which tables to concatenate.
             table_header_rowspan (dict, optional): Number of header rows (rowspan) for each table in table_indices.
@@ -98,7 +100,7 @@ class PDFDocHandler(DocHandler):
                 self.logger.error("URL must be provided to download the file.")
                 raise ValueError("URL must be provided to download the file.")
             self.logger.info(f"Downloading PDF from {url} to {cache_file_path}")
-            cache_file_path = self.download(url, cache_file_name)
+            cache_file_path = self.download(url, cache_file_name, progress_callback=progress_callback)
         else:
             self.logger.info(f"Loading PDF from cache file {cache_file_path}")
 

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -5,7 +5,7 @@ of DICOM specification tables from standard sources, producing structured SpecMo
 """
 import logging
 import os
-from typing import Any, Optional, Dict, Type
+from typing import Any, Callable, Optional, Dict, Type
 
 from dcmspec.config import Config
 from dcmspec.spec_model import SpecModel
@@ -85,20 +85,30 @@ class SpecFactory:
         self.name_attr = name_attr or "elem_name"
         self.parser_kwargs = parser_kwargs or {}
 
-    def load_document(self, url: str, cache_file_name: str, force_download: bool = False) -> Any:
+    def load_document(self, 
+                    url: str, 
+                    cache_file_name: str, 
+                    force_download: bool = False, 
+                    progress_callback: Optional[Callable[[int], None]] = None
+                    ) -> Any:
         """Download, cache, and parse the specification file from a URL, returning the document object.
 
         Args:
             url (str): The URL to download the input file from.
             cache_file_name (str): Filename of the cached input file.
             force_download (bool): If True, always download the input file even if cached.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
 
         Returns:
             Any: The document object.
 
         """
         # This will download if needed and always parse/return the DOM
-        return self.input_handler.load_document(cache_file_name=cache_file_name, url=url, force_download=force_download)
+        return self.input_handler.load_document(cache_file_name=cache_file_name,
+                                                url=url,
+                                                force_download=force_download,
+                                                progress_callback=progress_callback
+                                                )
 
     def try_load_cache(
         self,

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -98,7 +98,9 @@ class SpecFactory:
             cache_file_name (str): Filename of the cached input file.
             force_download (bool): If True, always download the input file even if cached.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
-
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
+                
         Returns:
             Any: The document object.
 

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -4,6 +4,7 @@ Provides the XHTMLDocHandler class for downloading, caching, and parsing XHTML d
 from the DICOM standard, returning a BeautifulSoup DOM object.
 """
 
+from collections.abc import Callable
 import logging
 import os
 import re
@@ -30,7 +31,7 @@ class XHTMLDocHandler(DocHandler):
             self, cache_file_name: str,
             url: Optional[str] = None,
             force_download: bool = False,
-            progress_callback=None
+            progress_callback: 'Optional[Callable[[int], None]]' = None
     ) -> BeautifulSoup:
         """Open and parse an XHTML file, downloading it if needed.
 
@@ -39,6 +40,8 @@ class XHTMLDocHandler(DocHandler):
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool): If True, do not use cache and download the file from the URL.
             progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
+                The callback receives an integer percent (0-100). If the total file size is unknown,
+                the callback will be called with -1 to indicate indeterminate progress.
 
         Returns:
             BeautifulSoup: Parsed DOM.
@@ -55,7 +58,12 @@ class XHTMLDocHandler(DocHandler):
             cache_file_path = self.download(url, cache_file_name, progress_callback=progress_callback)
         return self.parse_dom(cache_file_path)
 
-    def download(self, url: str, cache_file_name: str, progress_callback=None) -> str:
+    def download(
+        self,
+        url: str,
+        cache_file_name: str,
+        progress_callback: 'Optional[Callable[[int], None]]' = None
+    ) -> str:
         """Download and cache an XHTML file from a URL.
 
         Uses the base class download method, saving as UTF-8 text and cleaning ZWSP/NBSP.

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -29,7 +29,8 @@ class XHTMLDocHandler(DocHandler):
     def load_document(
             self, cache_file_name: str,
             url: Optional[str] = None,
-            force_download: bool = False
+            force_download: bool = False,
+            progress_callback=None
     ) -> BeautifulSoup:
         """Open and parse an XHTML file, downloading it if needed.
 
@@ -37,6 +38,7 @@ class XHTMLDocHandler(DocHandler):
             cache_file_name (str): Path to the local cached XHTML file.
             url (str, optional): URL to download the file from if not cached or if force_download is True.
             force_download (bool): If True, do not use cache and download the file from the URL.
+            progress_callback (Optional[Callable[[int], None]]): Optional callback to report download progress.
 
         Returns:
             BeautifulSoup: Parsed DOM.
@@ -50,10 +52,10 @@ class XHTMLDocHandler(DocHandler):
         if need_download:
             if not url:
                 raise ValueError("URL must be provided to download the file.")
-            cache_file_path = self.download(url, cache_file_name)
+            cache_file_path = self.download(url, cache_file_name, progress_callback=progress_callback)
         return self.parse_dom(cache_file_path)
 
-    def download(self, url: str, cache_file_name: str) -> str:
+    def download(self, url: str, cache_file_name: str, progress_callback=None) -> str:
         """Download and cache an XHTML file from a URL.
 
         Uses the base class download method, saving as UTF-8 text and cleaning ZWSP/NBSP.
@@ -61,6 +63,7 @@ class XHTMLDocHandler(DocHandler):
         Args:
             url: The URL of the XHTML document to download.
             cache_file_name: The filename of the cached document.
+            progress_callback: Optional callback to report download progress.
 
         Returns:
             The file path where the document was saved.
@@ -70,7 +73,7 @@ class XHTMLDocHandler(DocHandler):
 
         """
         file_path = os.path.join(self.config.get_param("cache_dir"), "standard", cache_file_name)
-        return super().download(url, file_path, binary=False)
+        return super().download(url, file_path, binary=False, progress_callback=progress_callback)
 
     def clean_text(self, text: str) -> str:
         """Clean text content before saving.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,3 +223,42 @@ def mergemany_by_node_test_models():
         metadata_attrs=metadata_other
     )
     return current, second, third
+
+class DummyResponse:
+    """A dummy response object to simulate requests.get behavior in tests."""
+
+    def __init__(self, text="abc", content=None, status_code=200, headers=None, raise_exc=None, chunks=None):
+        """Initialize a dummy response."""
+        self.text = text
+        self.content = content if content is not None else text.encode("utf-8")
+        self.status_code = status_code
+        self.headers = headers if headers is not None else {"content-length": str(len(self.content))}
+        self._raise_exc = raise_exc
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        """Simulate raising an error for HTTP errors."""
+        if self._raise_exc:
+            raise self._raise_exc
+
+    def __enter__(self):
+        """Simulate entering a context."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Simulate exiting a context."""
+        pass
+
+    def iter_content(self, chunk_size=8192, decode_unicode=False):
+        """Simulate iterating over content in chunks."""
+        if self._chunks:
+            yield from self._chunks
+        elif decode_unicode:
+            yield self.text
+        else:
+            yield self.content
+
+@pytest.fixture
+def dummy_response():
+    """Return a dummy response object for testing."""
+    return DummyResponse

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,16 @@ def mergemany_by_node_test_models():
 class DummyResponse:
     """A dummy response object to simulate requests.get behavior in tests."""
 
-    def __init__(self, text="abc", content=None, status_code=200, headers=None, raise_exc=None, chunks=None, encoding="utf-8"):
+    def __init__(
+        self,
+        text="abc",
+        content=None,
+        status_code=200,
+        headers=None,
+        raise_exc=None,
+        chunks=None,
+        encoding="utf-8"
+    ):
         """Initialize a dummy response."""
         self.text = text
         self.content = content if content is not None else text.encode(encoding)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,14 +227,15 @@ def mergemany_by_node_test_models():
 class DummyResponse:
     """A dummy response object to simulate requests.get behavior in tests."""
 
-    def __init__(self, text="abc", content=None, status_code=200, headers=None, raise_exc=None, chunks=None):
+    def __init__(self, text="abc", content=None, status_code=200, headers=None, raise_exc=None, chunks=None, encoding="utf-8"):
         """Initialize a dummy response."""
         self.text = text
-        self.content = content if content is not None else text.encode("utf-8")
+        self.content = content if content is not None else text.encode(encoding)
         self.status_code = status_code
         self.headers = headers if headers is not None else {"content-length": str(len(self.content))}
         self._raise_exc = raise_exc
         self._chunks = chunks
+        self.encoding = encoding
 
     def raise_for_status(self):
         """Simulate raising an error for HTTP errors."""

--- a/tests/test_doc_handler.py
+++ b/tests/test_doc_handler.py
@@ -13,6 +13,27 @@ class DummyDocHandler(DocHandler):
         """Do nothing."""
         pass
 
+    def raise_for_status(self):
+        """Simulate a successful response."""
+        if self._raise_exc:
+            raise self._raise_exc
+
+    def __enter__(self):
+        """Simulate entering a context."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Simulate exiting a context."""
+        pass
+
+    def iter_content(self, chunk_size=8192, decode_unicode=False):
+        """Simulate iterating over content in chunks."""
+        # For binary, yield bytes; for text, yield string if decode_unicode else bytes
+        if decode_unicode:
+            yield self.text
+        else:
+            yield self.content
+
 def test_doc_handler_init_defaults():
     """Test DocHandler __init__ with default arguments."""
     handler = DummyDocHandler()
@@ -34,20 +55,15 @@ def test_doc_handler_init_type_errors():
     with pytest.raises(TypeError):
         DummyDocHandler(config="not_a_config")
 
-def test_download_success(monkeypatch, tmp_path, caplog):
+def test_download_success(monkeypatch, tmp_path, caplog, dummy_response):
     """Test that download saves text file and logs info."""
     handler = DummyDocHandler()
     file_name = "test.txt"
     file_path = tmp_path / file_name
 
-    class DummyResponse:
-        text = "abc"
-        status_code = 200
-        def raise_for_status(self): pass
-
-    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponse())
+    monkeypatch.setattr("requests.get", lambda url, timeout, **kwargs: dummy_response())
     with caplog.at_level("INFO"):
-        result_path = handler.download("http://example.com", str(file_path))
+        result_path = handler.download("http://example.com", str(file_path), progress_callback=None)
     assert result_path == str(file_path)
     assert os.path.exists(file_path)
     with open(file_path, "r", encoding="utf-8") as f:
@@ -55,18 +71,13 @@ def test_download_success(monkeypatch, tmp_path, caplog):
     assert f"Downloading document from http://example.com to {file_path}" in caplog.text
     assert f"Document downloaded to {file_path}" in caplog.text
 
-def test_download_success_binary(monkeypatch, tmp_path, caplog):
+def test_download_success_binary(monkeypatch, tmp_path, caplog, dummy_response):
     """Test that download saves binary file when binary=True."""
     handler = DummyDocHandler()
     file_name = "test.pdf"
     file_path = tmp_path / file_name
 
-    class DummyResponse:
-        content = b"\x25PDF-1.4"
-        status_code = 200
-        def raise_for_status(self): pass
-
-    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponse())
+    monkeypatch.setattr("requests.get", lambda url, timeout, **kwargs: dummy_response(content=b"\x25PDF-1.4"))
     with caplog.at_level("INFO"):
         result_path = handler.download("http://example.com", str(file_path), binary=True)
     assert result_path == str(file_path)
@@ -76,16 +87,18 @@ def test_download_success_binary(monkeypatch, tmp_path, caplog):
     assert f"Downloading document from http://example.com to {file_path}" in caplog.text
     assert f"Document downloaded to {file_path}" in caplog.text
 
-def test_download_failure_network(tmp_path, monkeypatch):
+def test_download_failure_network(tmp_path, monkeypatch, dummy_response):
     """Test that download raises RuntimeError on network error."""
     handler = DummyDocHandler()
     file_name = "test.txt"
     file_path = tmp_path / file_name
 
-    class DummyResponse:
-        def raise_for_status(self): raise requests.exceptions.RequestException("fail")
-
-    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponse())
+    monkeypatch.setattr(
+        "requests.get",
+        lambda url, timeout, **kwargs: dummy_response(
+            raise_exc=requests.exceptions.RequestException("fail")
+        )
+    )
     with pytest.raises(RuntimeError) as excinfo:
         handler.download("http://example.com", str(file_path))
     assert "Failed to download" in str(excinfo.value)
@@ -104,18 +117,13 @@ def test_download_failure_dir(monkeypatch):  # sourcery skip: simplify-generator
     assert "Failed to create directory for" in str(excinfo.value)
     assert "cannot create dir" in str(excinfo.value)
 
-def test_download_failure_save(monkeypatch, tmp_path):
+def test_download_failure_save(monkeypatch, tmp_path, dummy_response):
     """Test that download raises RuntimeError if saving the file fails."""
     handler = DummyDocHandler()
     file_name = "test.txt"
     file_path = tmp_path / file_name
 
-    class DummyResponse:
-        text = "abc"
-        status_code = 200
-        def raise_for_status(self): pass
-
-    monkeypatch.setattr("requests.get", lambda url, timeout: DummyResponse())
+    monkeypatch.setattr("requests.get", lambda url, timeout, **kwargs: dummy_response())
     # Patch builtins.open to raise OSError
     import builtins
     original_open = builtins.open
@@ -129,3 +137,53 @@ def test_download_failure_save(monkeypatch, tmp_path):
         handler.download("http://example.com", str(file_path))
     assert "Failed to save file" in str(excinfo.value)
     assert "save failed" in str(excinfo.value)
+
+def test_download_progress_callback_text(monkeypatch, tmp_path, dummy_response):
+    """Test that download calls progress_callback with correct percent values."""
+    handler = DummyDocHandler()
+    file_name = "test.txt"
+    file_path = tmp_path / file_name
+
+    # Simulate multiple chunks
+    chunks = ["a", "b", "c"]
+    monkeypatch.setattr(
+        "requests.get",
+        lambda url, timeout, **kwargs: dummy_response(
+            text="abc",
+            chunks=chunks,
+            headers={"content-length": "3"}
+        )
+    )
+
+    progress_values = []
+    def progress_callback(percent):
+        progress_values.append(percent)
+
+    handler.download("http://example.com", str(file_path), progress_callback=progress_callback)
+    assert progress_values == [33, 66, 100]
+
+def test_download_progress_callback_binary(monkeypatch, tmp_path, dummy_response):
+    """Test that download calls progress_callback with correct percent values for binary downloads."""
+    handler = DummyDocHandler()
+    file_name = "test.pdf"
+    file_path = tmp_path / file_name
+
+    # Simulate multiple binary chunks
+    chunks = [b"\x25", b"PDF", b"-1.4"]
+    total_size = sum(len(chunk) for chunk in chunks)
+    monkeypatch.setattr(
+        "requests.get",
+        lambda url, timeout, **kwargs: dummy_response(
+            content=b"".join(chunks), chunks=chunks, headers={"content-length": str(total_size)}
+        ),
+    )
+
+    progress_values = []
+    def progress_callback(percent):
+        progress_values.append(percent)
+
+    handler.download("http://example.com", str(file_path), binary=True, progress_callback=progress_callback)
+    # Should get progress for each chunk: 28, 71, 100 (for 3 chunks of 7 bytes)
+    assert progress_values[-1] == 100
+    assert all(0 < p <= 100 for p in progress_values)
+    assert len(progress_values) == 3

--- a/tests/test_iod_spec_builder.py
+++ b/tests/test_iod_spec_builder.py
@@ -11,7 +11,7 @@ class DummyFactory:
         """Initialize."""
         self.called = []
 
-    def load_document(self, url, cache_file_name, force_download=False):
+    def load_document(self, url, cache_file_name, force_download=False, progress_callback=None):
         """Patch loading the DOM."""
         self.called.append(("load_document", url, cache_file_name, force_download))
         return "FAKE_DOM"

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -88,7 +88,7 @@ def test_load_document_download(monkeypatch, patch_dirs):
     dummy_pdf.close = MagicMock()
     monkeypatch.setattr("os.path.exists", lambda path: False)
     monkeypatch.setattr("pdfplumber.open", lambda path: dummy_pdf)
-    monkeypatch.setattr(handler, "download", lambda url, cache_file_name: "test.pdf")
+    monkeypatch.setattr(handler, "download", lambda url, cache_file_name, progress_callback=None: "test.pdf")
     monkeypatch.setattr(handler, "extract_tables_pdfplumber", lambda pdf, pn: [])
     monkeypatch.setattr(handler, "concat_tables", lambda tables, table_id=None, pad_columns=None: {})
 

--- a/tests/test_spec_factory.py
+++ b/tests/test_spec_factory.py
@@ -23,7 +23,7 @@ class DummyInputHandler:
         self.logger = logging.getLogger("DummyInputHandler")
         self.cache_file_name = "file.xhtml"
 
-    def load_document(self, cache_file_name, url=None, force_download=False):
+    def load_document(self, cache_file_name, url=None, force_download=False, progress_callback=None):
         """Simulate getting a DOM from a file or URL."""
         self.called = True
         return "DOM"
@@ -127,7 +127,7 @@ def test_load_dom(monkeypatch):
     """Test load_dom returns the DOM and calls input_handler.load_document."""
     ih = DummyInputHandler()
     factory = SpecFactory(input_handler=ih)
-    dom = factory.load_document(url="http://example.com", cache_file_name="file.xhtml", force_download=True)
+    dom = factory.load_document(url="http://example.com", cache_file_name="file.xhtml", force_download=True, progress_callback=None)
     assert dom == "DOM"
     assert ih.called
 


### PR DESCRIPTION
- Modify download to request stream of 8kB chunks with no compression
- Add progress_callback to download method to report percentage progress
- Update tests
- Add progress to dcmspec_explorer UI app in status bar
- Add note for lxml in installation documentation dependencies

## Summary by Sourcery

Enable download progress reporting by streaming content in fixed-size chunks, exposing a progress_callback hook across document handlers, updating the UI to display progress, and enhancing tests and documentation accordingly

New Features:
- Add progress_callback parameter to download methods across handlers to report download progress
- Integrate progress reporting into dcmspec_explorer UI status bar with 10% update granularity

Enhancements:
- Stream downloads in 8kB chunks with no compression and refactor download into _download_binary and _download_text helper methods
- Propagate progress_callback through SpecFactory, XHTMLDocHandler, IODSpecBuilder, and PDFDocHandler

Documentation:
- Add note in installation documentation about lxml requirements and dependencies

Tests:
- Introduce dummy_response fixture and DummyResponse test helper for streaming mocks
- Add tests for progress_callback to verify percentage calculations for text and binary downloads
- Update existing download tests to accommodate streaming behavior and progress_callback parameter