### PR TITLE
Make small improvements to progress reporting

### DIFF
--- a/src/dcmspec/doc_handler.py
+++ b/src/dcmspec/doc_handler.py
@@ -11,7 +11,7 @@ import logging
 import requests
 
 from dcmspec.config import Config
-from dcmspec.progress import Progress, ProgressObserver
+from dcmspec.progress import Progress, ProgressObserver, calculate_percent
 # BEGIN LEGACY SUPPORT: Remove for int progress callback deprecation
 from dcmspec.progress import ProgressStatus, handle_legacy_callback
 from typing import Callable
@@ -119,7 +119,7 @@ class DocHandler:
         if not progress_observer:
             return
 
-        percent = -1 if not total or total <= 0 else min(round(downloaded * 100 / total), 100)
+        percent = calculate_percent(downloaded, total)
         if percent != last_percent[0]:
             progress_observer(Progress(percent, status=ProgressStatus.DOWNLOADING))
             last_percent[0] = percent

--- a/src/dcmspec/doc_handler.py
+++ b/src/dcmspec/doc_handler.py
@@ -118,7 +118,8 @@ class DocHandler:
         """
         if not progress_observer:
             return
-        percent = -1 if not total or total <= 0 else min(int(downloaded * 100 / total), 100)
+
+        percent = -1 if not total or total <= 0 else min(round(downloaded * 100 / total), 100)
         if percent != last_percent[0]:
             progress_observer(Progress(percent, status=ProgressStatus.DOWNLOADING))
             last_percent[0] = percent

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional, Union
 from dcmspec.spec_parser import SpecParser
 
 from dcmspec.dom_utils import DOMUtils
-from dcmspec.progress import Progress, ProgressStatus
+from dcmspec.progress import Progress, ProgressStatus, calculate_percent
 
 class DOMTableSpecParser(SpecParser):
     """Parser for DICOM specification tables in XHTML DOM format.
@@ -321,7 +321,7 @@ class DOMTableSpecParser(SpecParser):
                 self._create_node(node_name, row_data, row_nesting_level, level_nodes, root)
             # Only report progress for the root table
             if progress_observer is not None:
-                percent = int((idx + 1) * 100 / total_rows)
+                percent = calculate_percent(idx + 1, total_rows)
                 progress_observer(Progress(
                     percent,
                     status=ProgressStatus.PARSING_TABLE,

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -14,7 +14,7 @@ from dcmspec.spec_model import SpecModel
 
 # BEGIN LEGACY SUPPORT: Remove for int progress callback deprecation
 from typing import Callable
-from dcmspec.progress import Progress, ProgressStatus, ProgressObserver, add_progress_step, handle_legacy_callback
+from dcmspec.progress import Progress, ProgressStatus, ProgressObserver, add_progress_step, calculate_percent, handle_legacy_callback
 # END LEGACY SUPPORT
 
 class IODSpecBuilder:
@@ -251,7 +251,7 @@ class IODSpecBuilder:
                 )
             module_models[ref_value] = module_model
             if progress_observer and total_modules > 0:
-                percent = int((idx + 1) * 100 / total_modules)
+                percent = calculate_percent(idx + 1, total_modules)
                 progress_observer(Progress(
                     percent,
                     status=ProgressStatus.PARSING_IOD_MODULES,

--- a/src/dcmspec/progress.py
+++ b/src/dcmspec/progress.py
@@ -74,6 +74,12 @@ def offset_progress_steps(step_offset, total_steps):
         return wrapper
     return decorator
 
+def calculate_percent(downloaded, total):
+    """Calculate percent complete, rounded, or -1 if total is unknown/invalid."""
+    if not total or total <= 0:
+        return -1
+    return min(round(downloaded * 100 / total), 100)
+
 def handle_legacy_callback(
     progress_observer: Optional[Callable] = None,
     progress_callback: Optional[Callable] = None,

--- a/tests/test_doc_handler.py
+++ b/tests/test_doc_handler.py
@@ -160,7 +160,7 @@ def test_download_progress_callback_text(monkeypatch, tmp_path, dummy_response):
         progress_values.append(percent)
 
     handler.download("http://example.com", str(file_path), progress_callback=progress_callback)
-    assert progress_values == [33, 66, 100]
+    assert progress_values == [33, 67, 100]
 
 def test_download_progress_observer_text(monkeypatch, tmp_path, dummy_response):
     """Test that download calls progress_observer with Progress objects and correct status."""
@@ -186,7 +186,7 @@ def test_download_progress_observer_text(monkeypatch, tmp_path, dummy_response):
 
     handler.download("http://example.com", str(file_path), progress_observer=progress_observer)
     # Should get Progress objects with percent 33, 66, 100 and status DOWNLOADING
-    assert [p.percent for p in progress_events] == [33, 66, 100]
+    assert [p.percent for p in progress_events] == [33, 67, 100]
     assert all(isinstance(p, Progress) for p in progress_events)
     assert all(p.status == ProgressStatus.DOWNLOADING for p in progress_events)
 

--- a/tests/test_doc_handler.py
+++ b/tests/test_doc_handler.py
@@ -160,6 +160,7 @@ def test_download_progress_callback_text(monkeypatch, tmp_path, dummy_response):
         progress_values.append(percent)
 
     handler.download("http://example.com", str(file_path), progress_callback=progress_callback)
+    # Note: Percent values use round(), so 2/3 of 100 is 67, not 66.
     assert progress_values == [33, 67, 100]
 
 def test_download_progress_observer_text(monkeypatch, tmp_path, dummy_response):


### PR DESCRIPTION
- Use round in percent progress computation
- Update tests and add test for legacy callback

These improvements should have been part of the previous merge requests but the branch was merged before these were committed and pushed.

## Summary by Sourcery

Round progress percentage values in reporting and ensure legacy int-based progress callbacks are correctly supported, with tests updated to reflect the new behavior.

Enhancements:
- Use round instead of int for computing progress percentage in doc_handler._report_progress

Tests:
- Update download progress tests to expect rounded percent values (33, 67, 100)
- Add test for legacy int-based progress_callback behavior in SpecFactory.create_model