### PR TITLE
Fix unformatted parser arg issues #48 and #53

### DIFF
--- a/src/dcmspec/apps/iod_explorer/iod_explorer.py
+++ b/src/dcmspec/apps/iod_explorer/iod_explorer.py
@@ -720,7 +720,9 @@ class IODExplorer:
 
     def _format_module_reference(self, module_ref: str) -> str:
         """Format module reference as an HTML anchor into a DICOM Part 3 URL."""
-        soup = BeautifulSoup(module_ref, "lxml-xml")
+        # Use the built-in 'xml' parser for both full documents and fragments,
+        # since DICOM standard files and cell values are well-formed XHTML.
+        soup = BeautifulSoup(module_ref, "xml")
         anchor = soup.find("a", class_="xref")
         if not anchor or not anchor.has_attr("href"):
             return f"<span><b>Reference:</b> {module_ref}</span><br>"

--- a/src/dcmspec/apps/iod_explorer/iod_explorer.py
+++ b/src/dcmspec/apps/iod_explorer/iod_explorer.py
@@ -13,13 +13,20 @@ from typing import List, Tuple
 import re
 import logging
 import os
+
 from anytree import PreOrderIter
+from bs4 import BeautifulSoup
 
 from dcmspec.config import Config
 from dcmspec.iod_spec_builder import IODSpecBuilder
 from dcmspec.spec_factory import SpecFactory
 from dcmspec.xhtml_doc_handler import XHTMLDocHandler
 from dcmspec.dom_table_spec_parser import DOMTableSpecParser
+
+# Canonical DICOM Part 3 TOC (Table of Contents) URL
+PART3_TOC_URL = "https://dicom.nema.org/medical/dicom/current/output/chtml/part03/ps3.3.html"
+# Canonical DICOM Part 3 HTML URL
+PART3_HTML_URL = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
 
 
 class StatusManager:
@@ -170,7 +177,7 @@ class IODExplorer:
         # Initialize DOM parser for DICOM standard version extraction
         self.dom_parser = DOMTableSpecParser(logger=self.logger)
         # URL for DICOM Part 3 Table of Contents
-        self.part3_toc_url = "https://dicom.nema.org/medical/dicom/current/output/chtml/part03/ps3.3.html"
+        self.part3_toc_url = PART3_TOC_URL
         # Initialize list of all IODs
         self.iod_list = []
         # Store IOD models to keep AnyTree nodes in memory
@@ -665,8 +672,7 @@ class IODExplorer:
             details += f"<span><b>Usage:</b> {usage_display}</span><br>"
 
         if module_ref:
-            details += f"<span><b>Reference:</b> {module_ref}</span><br>"
-
+            details += self._format_module_reference(module_ref)
         return details
 
     def _generate_attribute_details(self, node):
@@ -712,6 +718,20 @@ class IODExplorer:
         else:
             return usage
 
+    def _format_module_reference(self, module_ref: str) -> str:
+        """Format module reference as an HTML anchor into a DICOM Part 3 URL."""
+        soup = BeautifulSoup(module_ref, "lxml-xml")
+        anchor = soup.find("a", class_="xref")
+        if not anchor or not anchor.has_attr("href"):
+            return f"<span><b>Reference:</b> {module_ref}</span><br>"
+        href = anchor["href"]
+        module_url = f"{PART3_HTML_URL}{href}" if href.startswith("#") else href
+        return (
+            f'<span><b>Reference:</b> '
+            f'<a href="{module_url}" target="_blank">{anchor.get_text(strip=True)}</a>'
+            f'</span><br>'
+        )
+
     def _format_type_display(self, elem_type):
         """Format DICOM attribute type into a readable display string."""
         type_map = {
@@ -753,7 +773,7 @@ class IODExplorer:
             or None if building failed.
 
         """
-        url = "https://dicom.nema.org/medical/dicom/current/output/html/part03.html"
+        url = PART3_HTML_URL
         cache_file_name = "Part3.xhtml"
         model_file_name = f"Part3_{table_id}_expanded.json"
         
@@ -762,13 +782,17 @@ class IODExplorer:
         
         # Create the IOD specification factory
         c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
+        c_iod_unformatted = {0: True, 1: True, 2: False, 3: True}
         n_iod_columns_mapping = {0: "module", 1: "ref", 2: "usage"}
+        n_iod_unformatted = {0: True, 1: False, 2: True}
         iod_columns_mapping = c_iod_columns_mapping if composite_iod else n_iod_columns_mapping
+        iod_unformatted = c_iod_unformatted if composite_iod else n_iod_unformatted
         iod_factory = SpecFactory(
             column_to_attr=iod_columns_mapping, 
             name_attr="module",
             config=self.config,
             logger=logger,  # Use the custom logger for progress tracking
+            parser_kwargs={"unformatted": iod_unformatted}
         )
         
         # Create the Modules specification factory

--- a/src/dcmspec/cli/iodattributes.py
+++ b/src/dcmspec/cli/iodattributes.py
@@ -86,9 +86,11 @@ def main():
     c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
     n_iod_columns_mapping = {0: "module", 1: "ref", 2: "usage"}
     iod_columns_mapping = c_iod_columns_mapping if composite_iod else n_iod_columns_mapping
+    parser_kwargs = {"unformatted": {0: True, 1: True, 2: False, 3: True}}
     iod_factory = SpecFactory(
         column_to_attr=iod_columns_mapping, 
         name_attr="module",
+        parser_kwargs=parser_kwargs,
         config=config,
     )
 

--- a/src/dcmspec/cli/iodattributes.py
+++ b/src/dcmspec/cli/iodattributes.py
@@ -86,11 +86,9 @@ def main():
     c_iod_columns_mapping = {0: "ie", 1: "module", 2: "ref", 3: "usage"}
     n_iod_columns_mapping = {0: "module", 1: "ref", 2: "usage"}
     iod_columns_mapping = c_iod_columns_mapping if composite_iod else n_iod_columns_mapping
-    parser_kwargs = {"unformatted": {0: True, 1: True, 2: False, 3: True}}
     iod_factory = SpecFactory(
         column_to_attr=iod_columns_mapping, 
         name_attr="module",
-        parser_kwargs=parser_kwargs,
         config=config,
     )
 

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -23,7 +23,7 @@ class DOMTableSpecParser(SpecParser):
     Inherits logging from SpecParser.
     """
 
-    def __init__(self, logger=None):
+    def __init__(self, logger: Optional[Any] = None):
         """Initialize the DOMTableSpecParser.
 
         Sets up the parser with an optional logger and a DOMUtils instance for DOM navigation.
@@ -43,7 +43,7 @@ class DOMTableSpecParser(SpecParser):
         column_to_attr: Dict[int, str],
         name_attr: str,
         include_depth: Optional[int] = None,  # None means unlimited
-        progress_observer: Optional[object] = None,        
+        progress_observer: Optional[Any] = None,
         skip_columns: Optional[list[int]] = None,
         unformatted: Optional[Union[bool, Dict[int, bool]]] = True,
     ) -> tuple[Node, Node]:
@@ -107,7 +107,7 @@ class DOMTableSpecParser(SpecParser):
         return metadata, content
 
     @contextmanager
-    def _visit_table(self, table_id, visited_tables):
+    def _visit_table(self, table_id: str, visited_tables: set) -> Any:
         """Context manager to temporarily add a table_id to the visited_tables set during recursion.
 
         Ensures that table_id is added to visited_tables when entering the context,
@@ -132,7 +132,7 @@ class DOMTableSpecParser(SpecParser):
         name_attr: str,
         table_nesting_level: int = 0,
         include_depth: Optional[int] = None,  # None means unlimited
-        progress_observer: Optional[object] = None,
+        progress_observer: Optional[Any] = None,
         skip_columns: Optional[list[int]] = None,
         visited_tables: Optional[set] = None,
         unformatted_list: Optional[list[bool]] = None,
@@ -262,14 +262,14 @@ class DOMTableSpecParser(SpecParser):
             self.logger.warning("DICOM Standard version not found")
         return version
 
-    def _version_from_book(self, dom):
+    def _version_from_book(self, dom: BeautifulSoup) -> Optional[str]:
         """Extract version of DICOM books in HTML format."""
         titlepage = dom.find("div", class_="titlepage")
         if titlepage:
             subtitle = titlepage.find("h2", class_="subtitle")
         return subtitle.text.split()[2] if subtitle else None
 
-    def _version_from_section(self, dom):
+    def _version_from_section(self, dom: BeautifulSoup) -> Optional[str]:
         """Extract version of DICOM sections in the CHTML format."""
         document_release = dom.find("span", class_="documentreleaseinformation")
         return document_release.text.split()[2] if document_release else None
@@ -287,8 +287,8 @@ class DOMTableSpecParser(SpecParser):
         unformatted_list: list[bool],
         level_nodes: Dict[int, Node],
         root: Node,
-        progress_observer: Optional[object] = None
-    ):
+        progress_observer: Optional[Any] = None
+    ) -> None:
         """Process all rows in the table, handling recursion, nesting, and node creation."""
         rows = table.find_all("tr")[1:]
         total_rows = len(rows)
@@ -342,7 +342,8 @@ class DOMTableSpecParser(SpecParser):
 
         If, after accounting for colspans and rowspans, the row has one fewer value than the number of logical columns
         in the mapping and if skip_columns is set, those columns will be skipped for this row, allowing for robust
-        alignment when a column is sometimes missing such as in the case of some of the Modules of a normalized IOD.
+        alignment when Module Tables and nested Attributes Tables may not have the same number of columns as it may be
+        for normalized IOD Modules.
 
         Args:
             row: The table row element (BeautifulSoup Tag for <tr> element).
@@ -359,54 +360,192 @@ class DOMTableSpecParser(SpecParser):
                 - The value physically present in the current row,
                 - Or a value carried over from a previous row due to rowspan.
 
-            This ensures that each row's dictionary contains values for all requested logical columns, regardless of
-            whether the value is physically present in the current row or carried forward from a previous row due to
-            rowspan. The result is a complete, logically-aligned mapping for each row in the table.
-
         """
         # Initialize rowspan trackers if not present
         if not hasattr(self, "_rowspan_trackers") or self._rowspan_trackers is None:
             self._rowspan_trackers = []
 
-        # Add cells from pending rowspans
-        cells, colspans, rowspans, physical_col_idx, logical_col_idx = self._handle_pending_rowspans()
+        num_logical_columns = len(self.column_to_attr)  # Number of logical columns, hence expected number of cells
+        logical_cells = []  # List to hold the logical cell values
+        logical_col_idx = 0  # Logical column index in the table, index of the attribute in column_to_attr, 0-based
+        physical_col_idx = 0  # Physical column index in the DOM, index of the <td> cell in the <tr>, 0-based
 
-        attr_indices = list(self.column_to_attr.keys())
+        # Iterator for the <td> elements in the current row
+        cell_iter = iter(row.find_all("td"))
+        num_physical_cells = len(row.find_all("td"))
 
-        # Process the actual cells in this row, using skip_columns to align indices
-        physical_col_idx = self._process_actual_cells(
-            row,
-            cells,
-            colspans,
-            rowspans,
-            physical_col_idx,
-            unformatted_list,
-            skip_columns=skip_columns,
-            logical_col_idx=logical_col_idx
+        # Only apply skip_columns if the row is missing exactly that many columns
+        apply_skip = (
+            skip_columns
+            and num_physical_cells == num_logical_columns - len(skip_columns)
         )
 
-        # Clean up rowspan trackers for cells that are no longer needed
+        # 1. Handle carried-forward cells from rowspans
+        logical_cells, logical_col_idx, physical_col_idx = self._handle_rowspan_cells(
+            logical_cells, logical_col_idx, physical_col_idx, num_logical_columns
+        )
+
+        # 2. Process each logical column in the row, extracting values from physical <td> cells
+        while logical_col_idx < num_logical_columns:
+            # Skip this logical column if requested and missing in the row
+            if apply_skip and logical_col_idx in skip_columns:
+                logical_col_idx += 1
+                continue
+
+            logical_cells, logical_col_idx, physical_col_idx = self._process_logical_column(
+                cell_iter, logical_cells, logical_col_idx, physical_col_idx, skip_columns, unformatted_list
+            )
+
+        # 3. Trim _rowspan_trackers to match the number of physical columns in this row
         if len(self._rowspan_trackers) > physical_col_idx:
             self._rowspan_trackers = self._rowspan_trackers[:physical_col_idx]
 
-        return (
-            self._align_row_with_skipped_columns(
-                cells, colspans, attr_indices, skip_columns
+        # 4. Map logical cells to attributes, omitting skipped columns if missing in the row
+        attr_indices = list(self.column_to_attr.keys())
+        if skip_columns and len(logical_cells) == len(self.column_to_attr) - len(skip_columns):
+            return self._map_cells_with_skipped_columns(
+                logical_cells, attr_indices, skip_columns
             )
-            if skip_columns
-            and len(cells) == len(self.column_to_attr) - len(skip_columns)
-            else self._align_row_default(cells, colspans, attr_indices)
-        )
+        else:
+            return self._map_cells_to_attributes(logical_cells, attr_indices)
     
-    def _align_row_with_skipped_columns(
-        self, cells, colspans, attr_indices, skip_columns
-    ):
-        """Align cells to attributes when skip_columns is used.
 
-        This method aligns the row's cells to the attribute indices, skipping the columns
-        specified in skip_columns. It is used when the row is missing exactly the number of
-        columns specified, ensuring the remaining cells are mapped to the correct attributes.
+    def _handle_rowspan_cells(
+        self,
+        logical_cells: list,
+        logical_col_idx: int,
+        physical_col_idx: int,
+        num_logical_columns: int
+    ) -> tuple[list, int, int]:
+        """Handle carried-forward cells from rowspans for the current row.
 
+        For each logical column, if a rowspan tracker is active for the current physical column,
+        use its carried-forward value for this logical column.
+        Advances logical and physical indices as needed.
+
+        Returns:
+            tuple: (logical_cells, logical_col_idx, physical_col_idx)
+                - logical_cells: The updated list of extracted cell values for the row.
+                - logical_col_idx: The next logical column index to process.
+                - physical_col_idx: The next physical column index to process.
+
+        """
+        while (
+            physical_col_idx < len(self._rowspan_trackers)
+            and logical_col_idx < num_logical_columns
+            and self._rowspan_trackers[physical_col_idx]
+            and self._rowspan_trackers[physical_col_idx]["rows_left"] > 0
+        ):
+            # Use carried-forward value for this logical column
+            value = self._rowspan_trackers[physical_col_idx]["value"]
+            logical_cells.append(value)
+            self._rowspan_trackers[physical_col_idx]["rows_left"] -= 1
+
+        # Advance to next logical column and past all physical columns spanned by the carried-forward cell
+            physical_col_idx += self._rowspan_trackers[physical_col_idx]["colspan"]
+            logical_col_idx += 1
+
+        return logical_cells, logical_col_idx, physical_col_idx
+
+
+    def _process_logical_column(
+        self,
+        cell_iter: Any,
+        logical_cells: list,
+        logical_col_idx: int,
+        physical_col_idx: int,
+        skip_columns: Optional[list[int]],
+        unformatted_list: Optional[list[bool]]
+    ) -> tuple[list, int, int]:
+        """Process a single logical column in the row.
+
+        Extract the value from the corresponding physical <td> cell (if present),
+        handle colspans and rowspans, and update logical and physical indices.
+
+        Returns:
+            tuple: (logical_cells, logical_col_idx, physical_col_idx)
+                - logical_cells: The updated list of extracted cell values for the row.
+                - logical_col_idx: The next logical column index to process.
+                - physical_col_idx: The next physical column index to process.
+
+        """
+        # Ensure _rowspan_trackers has an entry for this physical column
+        if physical_col_idx >= len(self._rowspan_trackers):
+            self._rowspan_trackers.append(None)
+
+        # Ensure logical_cells has an entry for this logical column (fill with None if missing in DOM)
+        try:
+            cell = next(cell_iter)
+        except StopIteration:
+            logical_cells.append(None)
+            logical_col_idx += 1
+            return logical_cells, logical_col_idx, physical_col_idx
+
+        # Check the logical column's unformatted setting
+        use_unformatted = (
+            unformatted_list[logical_col_idx]
+            if unformatted_list and logical_col_idx < len(unformatted_list)
+            else True
+        )
+        # Extract value for the current logical column using the specified unformatted setting
+        value = self._clean_extracted_text(
+            cell.get_text(separator="\n", strip=True) if use_unformatted else cell.decode_contents()
+        )
+
+        # Determine colspan and rowspan
+        colspan = int(cell.get("colspan", 1))
+        rowspan = int(cell.get("rowspan", 1))
+
+        # Add the value for the first logical column spanned by this cell
+        logical_cells.append(value)
+        # Add None for each additional logical column spanned by colspan, unless skipped
+        logical_cells.extend(
+            None
+            for j in range(1, colspan)
+            if not skip_columns or logical_col_idx + j not in skip_columns
+        )
+        
+        # Update rowspan tracker for each physical column spanned by this cell
+        for i in range(colspan):
+            while len(self._rowspan_trackers) <= physical_col_idx + i:
+                self._rowspan_trackers.append(None)
+            if rowspan > 1:
+                value_for_tracker = value if i == 0 else None
+                self._rowspan_trackers[physical_col_idx + i] = {
+                    "value": value_for_tracker,
+                    "rows_left": rowspan - 1,
+                    "colspan": 1,
+                }
+            else:
+                self._rowspan_trackers[physical_col_idx + i] = None
+
+        # Advance logical and physical column indices by colspan
+        physical_col_idx += colspan
+        logical_col_idx += colspan
+
+        return logical_cells, logical_col_idx, physical_col_idx
+
+
+    def _map_cells_with_skipped_columns(
+        self,
+        cells: list,
+        attr_indices: list[int],
+        skip_columns: list[int]
+    ) -> dict:
+        """Map the list of extracted cell values to the attribute names for this row in presence of skipped columns.
+
+        This method is used when skip_columns is set and the number of logical cells
+        matches the expected number of non-skipped columns. It ensures that only the
+        non-skipped attributes are present in the output dictionary.
+
+        Args:
+            cells (list): Extracted cell values for the row, in logical column order (excluding skipped columns).
+            attr_indices (list): Column indices (keys from column_to_attr) in logical order.
+            skip_columns (list): Column indices to skip.
+
+        Returns:
+            dict: Dictionary mapping attribute names to cell values (excluding skipped columns).
+            
         """
         attr_indices = [i for i in attr_indices if i not in skip_columns]
 
@@ -416,39 +555,37 @@ class DOMTableSpecParser(SpecParser):
         # Map the remaining cells to the correct attributes
         return {
             self.column_to_attr[attr_indices[attr_index]]: cell
-            for attr_index, (cell, colspan) in enumerate(zip(cells, colspans))
+            for attr_index, cell in enumerate(cells)
             if attr_index < len(attr_indices)
         }
 
-    def _align_row_default(self, cells, colspans, attr_indices):
-        """Align cells to attributes by default, handling colspans and missing cells.
-        
-        Always set all attributes, even if missing in this row, filling spanned columns with None
-        to maintain alignment with the column_to_attr mapping.
-        
+    def _map_cells_to_attributes(
+        self,
+        cells: list,
+        attr_indices: list[int]
+    ) -> dict:
+        """Map the list of extracted cell values to the attribute names for this row.
+
+        This method builds a dictionary mapping each attribute name (from column_to_attr)
+        to the corresponding value in the `cells` list. If there are fewer cells than attributes,
+        the remaining attributes are filled with None.
+
+        Args:
+            cells (list): List of extracted cell values for the row, in logical column order.
+            attr_indices (list): List of column indices (keys from column_to_attr) in logical order.
+
+        Returns:
+            dict: Dictionary mapping attribute names to cell values (or None if missing).
+
         """
         row_data = {}
-        cell_idx = 0
         attr_indices = sorted(attr_indices)
-        i = 0
-        while i < len(attr_indices):
-            attr = self.column_to_attr[attr_indices[i]]
-            if cell_idx < len(cells):
-                row_data[attr] = cells[cell_idx]
-                colsp = colspans[cell_idx] if cell_idx < len(colspans) else 1
-                # Fill in None for skipped columns due to colspan
-                for _ in range(1, colsp):
-                    i += 1
-                    if i < len(attr_indices):
-                        skipped_attr = self.column_to_attr[attr_indices[i]]
-                        row_data[skipped_attr] = None
-                cell_idx += 1
-            else:
-                row_data[attr] = None
-            i += 1
+        for i, attr_idx in enumerate(attr_indices):
+            attr = self.column_to_attr[attr_idx]
+            row_data[attr] = cells[i] if i < len(cells) else None
         return row_data
     
-    def _handle_pending_rowspans(self):
+    def _handle_pending_rowspans(self) -> tuple[list, list, list, int, int]:
         """Handle cells that are carried forward from previous rows due to rowspan.
 
         This method checks the internal _rowspan_trackers for any cells that are being
@@ -486,7 +623,13 @@ class DOMTableSpecParser(SpecParser):
 
         return cells, colspans, rowspans, physical_col_idx, logical_col_idx
 
-    def _enforce_unformatted_for_name_attr(self, column_to_attr, name_attr, unformatted_list):
+    def _enforce_unformatted_for_name_attr(
+        self,
+        column_to_attr: dict[int, str],
+        name_attr: str,
+        unformatted_list: list[bool]
+    ) -> None:
+        """Enforce unformatted=True for the name_attr column if it is not already set."""
         name_attr_col = next((col_idx for col_idx, attr in column_to_attr.items() if attr == name_attr), None)
         if name_attr_col is not None and not unformatted_list[name_attr_col]:
             unformatted_list[name_attr_col] = True
@@ -496,109 +639,12 @@ class DOMTableSpecParser(SpecParser):
                     "Forcing unformatted=True for this column to ensure correct parsing."
                 )
 
-    def _process_actual_cells(
+    def _check_circular_reference(
         self,
-        row,
-        cells,
-        colspans,
-        rowspans,
-        physical_col_idx,
-        unformatted_list,
-        skip_columns=None,
-        logical_col_idx=0
-    ):
-        """Process the actual (non-rowspan) cells in a table row, extracting text or HTML as needed.
-
-        The "actual (non-rowspan) cells" are the BeautifulSoup Tag objects for <td> elements
-        that are physically present in the current row of the HTML table. These do not include
-        cells that are logically present due to a rowspan from a previous row; those are handled
-        separately by _handle_pending_rowspans.
-
-        This method iterates through the logical columns of the row, skipping columns as specified,
-        and for each column:
-            - If a cell is present in the current row, extracts its value (as text or HTML depending on
-                the boolean value in unformatted_list).
-            - If a cell is carried forward due to rowspan, it is already handled by _handle_pending_rowspans.
-            - Updates the physical and logical column indices as it processes each cell.
-
-        Args:
-            row: The BeautifulSoup Tag for the current table row.
-            cells: List to append extracted cell values to.
-            colspans: List to append colspans for each cell.
-            rowspans: List to append rowspans for each cell.
-            physical_col_idx: The current physical column index in the HTML table (including colspans).
-            unformatted_list: List of booleans indicating whether to extract each column as unformatted text.
-            skip_columns: Optional list of logical column indices to skip.
-            logical_col_idx: The current logical column index in the data model (default 0).
-
-        Returns:
-            int: The updated physical_col_idx after processing all cells in the row.
-
-        Note:
-            - physical_col_idx tracks the actual position in the HTML table, including colspans.
-            - logical_col_idx tracks the logical data model column, incremented by 1 per cell.
-            - This method ensures correct alignment between the HTML table and the data model,
-            even in the presence of rowspans and colspans.
-
-        """
-        cell_iter = iter(row.find_all("td"))
-        num_columns = len(unformatted_list)
-        while logical_col_idx < num_columns:
-            # Skip columns as needed
-            if skip_columns and logical_col_idx in skip_columns:
-                logical_col_idx += 1
-                continue
-
-            if physical_col_idx >= len(self._rowspan_trackers):
-                self._rowspan_trackers.append(None)
-
-            try:
-                cell = next(cell_iter)
-            except StopIteration:
-                # If we run out of cells, fill the rest with None
-                cells.append(None)
-                colspans.append(1)
-                rowspans.append(1)
-                logical_col_idx += 1
-                continue
-
-            use_unformatted = (
-                unformatted_list[logical_col_idx]
-                if unformatted_list and logical_col_idx < len(unformatted_list)
-                else True
-            )
-            if use_unformatted:
-                cell_text = self._clean_extracted_text(cell.get_text(separator="\n", strip=True))
-            else:
-                cell_text = self._clean_extracted_text(cell.decode_contents())
-
-            colspan = int(cell.get("colspan", 1))
-            rowspan = int(cell.get("rowspan", 1))
-
-            # Add the value for the first logical column spanned by this cell
-            cells.append(cell_text)
-            colspans.append(colspan)
-            rowspans.append(rowspan)
-
-            # Set rowspan trackers for all physical columns spanned
-            for i in range(colspan):
-                while len(self._rowspan_trackers) <= physical_col_idx + i:
-                    self._rowspan_trackers.append(None)
-                if rowspan > 1:
-                    value_for_tracker = cell_text if i == 0 else None
-                    self._rowspan_trackers[physical_col_idx + i] = {
-                        "value": value_for_tracker,
-                        "rows_left": rowspan - 1,
-                        "colspan": 1,
-                    }
-                else:
-                    self._rowspan_trackers[physical_col_idx + i] = None
-
-            physical_col_idx += colspan
-            logical_col_idx += 1  # Only advance by 1 logical column per <td>
-        return physical_col_idx
-
-    def _check_circular_reference(self, row, visited_tables, table_nesting_level):
+        row: Tag,
+        visited_tables: set,
+        table_nesting_level: int
+    ) -> bool:
         """Check for circular reference before attempting to parse an included table.
 
         Returns:
@@ -654,15 +700,26 @@ class DOMTableSpecParser(SpecParser):
         self._nest_included_table(included_table_tree, level_nodes, table_nesting_level, root)
 
     def _nest_included_table(
-        self, included_table_tree: Node, level_nodes: Dict[int, Node], row_nesting_level: int, root: Node
+        self,
+        included_table_tree: Node,
+        level_nodes: Dict[int, Node],
+        row_nesting_level: int,
+        root: Node
     ) -> None:
+        """Nest the included table tree under the appropriate parent node."""
         parent_node = level_nodes.get(row_nesting_level - 1, root)
         for child in included_table_tree.children:
             child.parent = parent_node
 
     def _create_node(
-        self, node_name: str, row_data: Dict[str, Any], row_nesting_level: int, level_nodes: Dict[int, Node], root: Node
+        self,
+        node_name: str,
+        row_data: Dict[str, Any],
+        row_nesting_level: int,
+        level_nodes: Dict[int, Node],
+        root: Node
     ) -> None:
+        """Create a new node and attach it to the appropriate parent."""
         parent_node = level_nodes.get(row_nesting_level - 1, root)
         self.logger.debug(
             f"Nesting Level: {row_nesting_level}, Name: {node_name}, "
@@ -671,7 +728,11 @@ class DOMTableSpecParser(SpecParser):
         node = Node(node_name, parent=parent_node, **row_data)
         level_nodes[row_nesting_level] = node
 
-    def _extract_header(self, table: Tag, column_to_attr: Dict[int, str]) -> list:
+    def _extract_header(
+        self,
+        table: Tag,
+        column_to_attr: Dict[int, str]
+    ) -> list[str]:
         """Extract headers from the table and saves them in the headers attribute.
 
         Realign the keys in column_to_attr to consecutive indices if the number of columns in the table

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -51,8 +51,12 @@ class IODSpecBuilder:
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
             ref_attr (Optional[str]): Attribute name to use for module references. If None, defaults to "ref".
 
-        The builder is initialized with factories for the IOD and module models. By default, the same
-        factory is used for both, but a different factory can be provided for modules if needed.
+        Raises:
+            ValueError: If `ref_attr` is not a non-empty string.
+
+        Note:
+            The builder is initialized with factories for the IOD and module models. By default, the same
+            factory is used for both, but a different factory can be provided for modules if needed.
 
         """
         self.logger = logger or logging.getLogger(self.__class__.__name__)
@@ -61,7 +65,9 @@ class IODSpecBuilder:
         self.module_factory = module_factory or self.iod_factory
         self.dom_utils = DOMUtils(logger=self.logger)
         self.ref_attr = ref_attr or "ref"
-
+        if not isinstance(self.ref_attr, str) or not self.ref_attr.strip():
+            raise ValueError("ref_attr must be a non-empty string.")
+        
     def build_from_url(
         self,
         url: str,

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -8,13 +8,22 @@ import os
 from typing import Any, Dict, List, Optional
 
 from anytree import Node
+from bs4 import BeautifulSoup
+
 from dcmspec.dom_utils import DOMUtils
 from dcmspec.spec_factory import SpecFactory
 from dcmspec.spec_model import SpecModel
 
 # BEGIN LEGACY SUPPORT: Remove for int progress callback deprecation
 from typing import Callable
-from dcmspec.progress import Progress, ProgressStatus, ProgressObserver, add_progress_step, calculate_percent, handle_legacy_callback
+from dcmspec.progress import (
+    Progress,
+    ProgressStatus,
+    ProgressObserver,
+    add_progress_step,
+    calculate_percent,
+    handle_legacy_callback,
+)
 # END LEGACY SUPPORT
 
 class IODSpecBuilder:
@@ -30,6 +39,7 @@ class IODSpecBuilder:
         iod_factory: SpecFactory = None,
         module_factory: SpecFactory = None,
         logger: logging.Logger = None,
+        ref_attr: str = None,
     ):
         """Initialize the IODSpecBuilder.
 
@@ -39,6 +49,7 @@ class IODSpecBuilder:
             iod_factory (Optional[SpecFactory]): Factory for building the IOD model. If None, uses SpecFactory().
             module_factory (Optional[SpecFactory]): Factory for building module models. If None, uses iod_factory.
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
+            ref_attr (Optional[str]): Attribute name to use for module references. If None, defaults to "ref".
 
         The builder is initialized with factories for the IOD and module models. By default, the same
         factory is used for both, but a different factory can be provided for modules if needed.
@@ -49,6 +60,7 @@ class IODSpecBuilder:
         self.iod_factory = iod_factory or SpecFactory(logger=self.logger)
         self.module_factory = module_factory or self.iod_factory
         self.dom_utils = DOMUtils(logger=self.logger)
+        self.ref_attr = ref_attr or "ref"
 
     def build_from_url(
         self,
@@ -151,8 +163,8 @@ class IODSpecBuilder:
                 Progress(-1, status=ProgressStatus.PARSING_IOD_MODULES, step=3, total_steps=total_steps)
             )
 
-        # Find all nodes with a "ref" attribute in the IOD Modules model
-        nodes_with_ref = [node for node in iodmodules_model.content.children if hasattr(node, "ref")]
+        # Find all nodes with a reference attribute in the IOD Modules model
+        nodes_with_ref = [node for node in iodmodules_model.content.children if hasattr(node, self.ref_attr)]
 
         # Build or load module models for each referenced section
         module_models = self._build_module_models(
@@ -207,7 +219,7 @@ class IODSpecBuilder:
         step: int,
         total_steps: int,
         progress_observer: Optional['ProgressObserver'] = None
-    ) -> Dict[str, Any]:        
+    ) -> Dict[str, Any]:
         """Build or load module models for each referenced section, reporting progress."""
         module_models: Dict[str, Any] = {}
         total_modules = len(nodes_with_ref)
@@ -216,11 +228,13 @@ class IODSpecBuilder:
                 Progress(0, status=ProgressStatus.PARSING_IOD_MODULES, step=step, total_steps=total_steps)
                 )
         for idx, node in enumerate(nodes_with_ref):
-            ref_value = getattr(node, "ref", None)
-            if not ref_value:
+            ref_value = getattr(node, self.ref_attr, None)
+            section_id = self._get_section_id_from_ref(ref_value)
+            if not section_id:
                 continue
-            section_id = f"sect_{ref_value}"
+
             module_table_id = self.dom_utils.get_table_id_from_section(dom, section_id)
+            self.logger.debug(f"First Module table_id for section_id={repr(section_id)}: {repr(module_table_id)}")
             if not module_table_id:
                 self.logger.warning(f"No table found for section id {section_id}")
                 continue
@@ -249,7 +263,7 @@ class IODSpecBuilder:
                     json_file_name=module_json_file_name,
                     progress_observer=progress_observer,
                 )
-            module_models[ref_value] = module_model
+            module_models[section_id] = module_model
             if progress_observer and total_modules > 0:
                 percent = calculate_percent(idx + 1, total_modules)
                 progress_observer(Progress(
@@ -259,7 +273,34 @@ class IODSpecBuilder:
                     total_steps=total_steps
                 ))
         return module_models
-    
+
+    def _get_section_id_from_ref(self, ref_value: str) -> Optional[str]:
+        """Normalize a ref_value (plain text or HTML anchor) to a section_id.
+
+        For HTML, extract the href after '#'. For plain text, always prepend 'sect_'.
+        Strips whitespace for robust lookup.
+        (Do NOT lowercase: DICOM IDs are mixed case and BeautifulSoup search is case-sensitive.)
+        """
+        if not ref_value:
+            return None
+        if "<a " not in ref_value:
+            # Always prepend 'sect_' for plain text references, strip only
+            section_id = f"sect_{ref_value.strip()}"
+            self.logger.debug(f"Extracted section_id from plain text reference: {repr(section_id)}")
+            return section_id
+        soup = BeautifulSoup(ref_value, "lxml-xml")
+        # Find the anchor with class "xref" (the actual module reference)
+        anchor = soup.find("a", class_="xref")
+        if anchor and anchor.has_attr("href"):
+            href = anchor["href"].strip()
+            section_id = href.split("#", 1)[-1] if "#" in href else href
+            section_id = section_id.strip()
+            self.logger.debug(f"Extracted section_id from HTML reference: {repr(section_id)}")
+            return section_id
+        else:
+            self.logger.debug(f"No section_id could be extracted from ref_value={repr(ref_value)}")
+            return None
+
     def _create_expanded_model(self, iodmodules_model: SpecModel, module_models: dict) -> SpecModel:
         """Create the expanded model by attaching Module nodes content to IOD nodes."""
         # Use the first module's metadata node for the expanded model
@@ -271,9 +312,10 @@ class IODSpecBuilder:
         # and for each referenced module, its content's children will be attached directly under the iod node
         iod_content = Node("content")
         for iod_node in iodmodules_model.content.children:
-            ref_value = getattr(iod_node, "ref", None)
-            if ref_value and ref_value in module_models:
-                module_content = module_models[ref_value].content
+            ref_value = getattr(iod_node, self.ref_attr, None)
+            section_id = self._get_section_id_from_ref(ref_value)
+            if section_id and section_id in module_models:
+                module_content = module_models[section_id].content
                 for child in list(module_content.children):
                     child.parent = iod_node
             iod_node.parent = iod_content

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -74,6 +74,10 @@ class SpecFactory:
         Raises:
             TypeError: If config is not a Config instance or None.
 
+        Note:
+            `column_to_attr` and related flags (such as `unformatted`) are dicts to support non-sequential
+            column mappings.
+
         """
         import logging
         if config is not None and not isinstance(config, Config):

--- a/src/dcmspec/xhtml_doc_handler.py
+++ b/src/dcmspec/xhtml_doc_handler.py
@@ -151,9 +151,11 @@ class XHTMLDocHandler(DocHandler):
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            # dom = BeautifulSoup(content, "html.parser")  # use python HTML parser. Fine for XHTML. Unreliable for XML.
-            # dom = BeautifulSoup(content, "lxml")  # use lxml package parser. Default to HTML and generates a warning.
-            dom = BeautifulSoup(content, features="xml")  # use lxml package parser. Force using XML. Safest choice.
+            # Use the built-in 'xml' parser since DICOM files and cell values are well-formed XHTML.
+            # "html.parser" is fine for XHTML but unreliable for strict XML.
+            # "lxml" defaults to HTML mode and generates a warning for XML.
+            # "lxml-xml" forces XML parsing but adds the lxml dependency.
+            dom = BeautifulSoup(content, features="xml") 
             self.logger.info("XHTML DOM read successfully")
 
             return dom

--- a/tests/fixtures_dom_tables.py
+++ b/tests/fixtures_dom_tables.py
@@ -12,7 +12,9 @@ def docbook_sample_dom_1():
                 <tbody>
                     <tr>
                         <th colspan="1" align="center" rowspan="1">
-                            <span class="documentreleaseinformation">DICOM PS3.3 2025b - Information Object Definitions</span>
+                            <span class="documentreleaseinformation">
+                                DICOM PS3.3 2025b - Information Object Definitions
+                            </span>
                         </th>
                     </tr>
                 </tbody>
@@ -191,7 +193,7 @@ def table_colspan_dom():
 
 @pytest.fixture
 def table_mixed_colspan_dom():
-    """Return a DocBook-style XHTML DOM with a table where some rows have a missing column (colspan) and others do not."""
+    """Return a DocBook-style XHTML DOM with a table where some rows have a merged columns and others do not."""
     xhtml = """
     <html xmlns="http://www.w3.org/1999/xhtml">
         <body>
@@ -289,7 +291,7 @@ def table_colspan_rowspan_dom():
                                     <td><p>B</p></td>
                                 </tr>
                                 <tr valign="top">
-                                    <td><p>C</p></td>
+                                    <td><p><span class="foo">C</span></p></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -337,7 +339,9 @@ def table_include_dom():
                                 <tr valign="top">
                                     <td align="left" colspan="4" rowspan="1">
                                         <p>
-                                            <span class="italic">Include <a class="xref" href="#table_MACRO">Table Macro</a></span>
+                                            <span class="italic">
+                                                Include <a class="xref" href="#table_MACRO">Table Macro</a>
+                                            </span>
                                         </p>
                                     </td>
                                 </tr>
@@ -395,7 +399,9 @@ def section_dom():
             </div>
         </div>
         <p>
-            <a class="xref" href="#table_C.7-1" title="Table&nbsp;C.7-1.&nbsp;Patient Module Attributes" shape="rect">Table&nbsp;C.7-1</a>
+            <a class="xref" href="#table_C.7-1" title="Table&nbsp;C.7-1.&nbsp;Patient Module Attributes" shape="rect">
+                Table&nbsp;C.7-1
+            </a>
         </p>
         <div class="table">
             <a id="table_C.7-1" shape="rect"></a>

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -334,6 +334,39 @@ def test_parse_table_colspan_rowspan(table_colspan_rowspan_dom):  # noqa: F811
     assert children[1].col1 == "A"  # from rowspan+colspan
     assert children[1].col3 == "C"
 
+
+def test_parse_table_colspan_rowspan_unformatted(table_colspan_rowspan_dom):  # noqa: F811
+    """Test parse_table handles both colspan and rowspan together, and unformatted_list."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3"}
+    # Set unformatted_list so that col2 returns HTML, others return text
+    unformatted_list = [True, False, True]
+    node = parser.parse_table(
+        dom=table_colspan_rowspan_dom,
+        table_id="table_COLSPANROWSPAN",
+        column_to_attr=column_to_attr,
+        name_attr="col1",
+        unformatted_list=unformatted_list
+    )
+    children = list(node.children)
+    # Print the actual values for inspection
+    print("Row 0:", "col1:", repr(children[0].col1), "col2:", repr(children[0].col2), "col3:", repr(children[0].col3))
+    print("Row 1:", "col1:", repr(children[1].col1), "col2:", repr(children[1].col2), "col3:", repr(children[1].col3))
+    # There should be 2 rows
+    assert len(children) == 2
+
+    # First row: col1="A", col2=None (colspan), col3="<p>B</p>"
+    assert children[0].col1 == "A"
+    assert hasattr(children[0], "col2")
+    assert children[0].col2 is None
+    assert children[0].col3.strip() == "<p>B</p>"
+
+    # Second row: col1="A" (from rowspan+colspan), col2=None (colspan), col3="C"
+    assert children[1].col1 == "A"
+    assert hasattr(children[1], "col2")
+    assert children[1].col2 is None
+    assert children[1].col3 == "C"
+
 def test_parse_table_include_triggers_recursion(table_include_dom):  # noqa: F811
     """Test that parse_table handles an 'Include' row and recursively parses the included table."""
     parser = DOMTableSpecParser()

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -281,6 +281,26 @@ def test_parse_table_skip_columns_all_cells_not_in_dom(docbook_sample_dom_1):  #
     # The column_to_attr should not include the missing column
     assert metadata.column_to_attr == {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
 
+def test_parse_table_skip_columns_column_present_not_skipped(docbook_sample_dom_1):  # noqa: F811
+    """Test that specifying skip_columns for a column that is present in the DOM does NOT skip it."""
+    parser = DOMTableSpecParser()
+    # All columns are present in the DOM, but we specify skip_columns for column 2 ("elem_type")
+    column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type", 3: "elem_desc"}
+    node = parser.parse_table(
+        dom=docbook_sample_dom_1,
+        table_id="table_SAMPLE",
+        column_to_attr=column_to_attr,
+        name_attr="elem_name",
+        skip_columns=[2],  # "elem_type" is present in the DOM, so should NOT be skipped
+    )
+    children = list(node.children)
+    assert len(children) == 2
+    # "elem_type" should be present and have the correct value
+    assert hasattr(children[0], "elem_type")
+    assert children[0].elem_type == "1"
+    assert hasattr(children[1], "elem_type")
+    assert children[1].elem_type == "2"
+
 def test_parse_table_skip_columns_all_cells_colspan(table_colspan_dom):  # noqa: F811
     """Test parse_table with skip_columns skips columns for all rows when all cells are missing that column."""
     parser = DOMTableSpecParser()
@@ -336,11 +356,11 @@ def test_parse_table_colspan_rowspan(table_colspan_rowspan_dom):  # noqa: F811
 
 
 def test_parse_table_colspan_rowspan_unformatted(table_colspan_rowspan_dom):  # noqa: F811
-    """Test parse_table handles both colspan and rowspan together, and unformatted_list."""
+    """Test parse_table handles both colspan and rowspan together, and unformatted_list, including HTML alignment."""
     parser = DOMTableSpecParser()
     column_to_attr = {0: "col1", 1: "col2", 2: "col3"}
-    # Set unformatted_list so that col2 returns HTML, others return text
-    unformatted_list = [True, False, True]
+    # Set unformatted_list so that col3 returns HTML, others return text
+    unformatted_list = [True, False, False]
     node = parser.parse_table(
         dom=table_colspan_rowspan_dom,
         table_id="table_COLSPANROWSPAN",
@@ -361,11 +381,11 @@ def test_parse_table_colspan_rowspan_unformatted(table_colspan_rowspan_dom):  # 
     assert children[0].col2 is None
     assert children[0].col3.strip() == "<p>B</p>"
 
-    # Second row: col1="A" (from rowspan+colspan), col2=None (colspan), col3="C"
+    # Second row: col1="A" (from rowspan+colspan), col2=None (colspan), col3="<p><span class=\"foo\">C</span></p>"
     assert children[1].col1 == "A"
     assert hasattr(children[1], "col2")
     assert children[1].col2 is None
-    assert children[1].col3 == "C"
+    assert children[1].col3.strip() == '<p><span class="foo">C</span></p>'
 
 def test_parse_table_include_triggers_recursion(table_include_dom):  # noqa: F811
     """Test that parse_table handles an 'Include' row and recursively parses the included table."""


### PR DESCRIPTION
- Fix column alignement in Module tables parsing related to rowspan
- Add support for HTML format for Module table "Reference" column in IODSpecBuilder
- Remove hard-coding of attribute name for Module table "Reference" column in IODSpecBuilder

## Summary by Sourcery

Fix unformatted parser argument handling and robustly align columns in the DOMTableSpecParser, introduce configurable and HTML-aware module references in IODSpecBuilder, and render clickable module links in the IOD explorer.

New Features:
- Allow configurable module reference attribute name in IODSpecBuilder via a new ref_attr parameter
- Support HTML parsing of module reference values and normalize them to section IDs
- Render module references as clickable HTML anchors in the IOD explorer UI

Bug Fixes:
- Fix unformatted extraction and column alignment in DOMTableSpecParser to correctly handle rowspan, colspan, and skip_columns inputs

Enhancements:
- Refactor DOMTableSpecParser._extract_row_data into focused methods for handling rowspans, logical columns, and mapping to attributes
- Add type annotations across DOMTableSpecParser methods
- Replace hard-coded 'ref' attribute usage with the configurable ref_attr

Tests:
- Add tests for custom reference attribute handling in IODSpecBuilder
- Add tests for unformatted, colspan, and rowspan behavior in DOMTableSpecParser