### PR TITLE
Add module registry mode to IODSpecBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ See the [Installation Guide](https://dwikler.github.io/dcmspec/installation/) fo
 - For API usage, see the [API documentation](https://dwikler.github.io/dcmspec/api/).
 - For CLI usage, see the [CLI Applications Overview](https://dwikler.github.io/dcmspec/cli/).
 
+## Release Notes
+
+See the [Release Notes](https://dwikler.github.io/dcmspec/changelog/) for a summary of changes, improvements, and breaking updates in each version.
+
 ## Configuration
 
 See [Configuration & Caching](https://dwikler.github.io/dcmspec/configuration/) for details on configuring cache and other settings.

--- a/docs/api/module_registry.md
+++ b/docs/api/module_registry.md
@@ -1,0 +1,1 @@
+::: dcmspec.module_registry.ModuleRegistry

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+These release notes summarize key changes, improvements, and breaking updates for each version of **dcmspec**.
+
+## [0.2.0] - 2025-09-13
+
+### Changed
+
+- **Breaking change:** `IODSpecBuilder.build_from_url` now returns a tuple `(iod_model, module_models)` instead of just the IOD model. All callers must be updated to unpack the tuple.
+- Updated CLI and UI applications to support new return value.
+- Added registry mode to `IODSpecBuilder` for efficient module model sharing.
+
+## [0.1.0] - 2025-05-25
+
+### Added
+
+- Initial release.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,4 +13,6 @@ For setup instructions, refer to the [Installation](installation.md) page. Infor
 
 ---
 
+See the [Release Notes](changelog.md) for a summary of changes, improvements, and breaking updates in each version.
+
 Further information is available in the [GitHub repository](https://github.com/dwikler/dcmspec).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
           - ServiceAttributeModel: api/service_attribute_model.md
           - SpecFactory: api/spec_factory.md
           - IODSpecBuilder: api/iod_spec_builder.md
+          - ModuleRegistry: api/module_registry.md
       - Parse Classes:
           - SpecParser: api/spec_parser.md
           - DOMTableSpecParser: api/dom_table_spec_parser.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_name: DCMspec Documentation
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Release Notes: changelog.md
   - Configuration & Caching: configuration.md
   - CLI Applications:
       - CLI Overview: cli/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dcmspec"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = [
     {name = "David Wikler",email = "david.wikler@ulb.ac.be"}

--- a/src/dcmspec/apps/iod_explorer/iod_explorer.py
+++ b/src/dcmspec/apps/iod_explorer/iod_explorer.py
@@ -541,7 +541,7 @@ class IODExplorer:
             self.root.update()
 
             # Build the IOD model and populate the treeview
-            model = self._build_iod_model(table_id, self.logger)
+            model, _ = self._build_iod_model(table_id, self.logger)
             self._update_treeview_and_details(item, model, table_id, title, iod_type)
 
         except Exception as e:

--- a/src/dcmspec/cli/iodattributes.py
+++ b/src/dcmspec/cli/iodattributes.py
@@ -105,7 +105,7 @@ def main():
     builder = IODSpecBuilder(iod_factory=iod_factory, module_factory=module_factory)
 
     # Download, parse, and cache the combined model
-    model = builder.build_from_url(
+    model, _ = builder.build_from_url(
         url=url,
         cache_file_name=cache_file_name,
         json_file_name=model_file_name,

--- a/src/dcmspec/cli/upsioddimseattributes.py
+++ b/src/dcmspec/cli/upsioddimseattributes.py
@@ -245,7 +245,7 @@ def main():
         logger=logger
     )
     builder = IODSpecBuilder(iod_factory=iod_factory, module_factory=module_factory, logger=logger)
-    iod_model = builder.build_from_url(
+    iod_model, _ = builder.build_from_url(
         url=iod_url,
         cache_file_name=iod_cache_file,
         json_file_name=iod_model_file,

--- a/src/dcmspec/dom_utils.py
+++ b/src/dcmspec/dom_utils.py
@@ -20,9 +20,12 @@ class DOMUtils:
     with optional logging for warnings and debug information.
 
     Typical usage:
+        ```python
         dom_utils = DOMUtils(logger=logger)
         table = dom_utils.get_table(dom, table_id)
         table_id = dom_utils.get_table_id_from_section(dom, section_id)
+        ```
+
     """
 
     def __init__(self, logger: Optional[logging.Logger] = None):
@@ -70,9 +73,13 @@ class DOMUtils:
     
     def get_table_id_from_section(self, dom: BeautifulSoup, section_id: str) -> Optional[str]:
         """Get the id of the first table in a section.
-        
-        Retrieve the first table_id (anchor id) of a <div class="table"> inside a <div class="section">
-        that contains an <a> anchor with the given section id.
+
+        Retrieve the first table_id (anchor id) of a `<div class="table">` inside a `<div class="section">`
+        that contains an anchor tag with the given section id, e.g.:
+
+        ```html
+        <a id="table_C.7-1" shape="rect"></a>
+        ```
 
         Args:
             dom (BeautifulSoup): The parsed XHTML DOM object.

--- a/src/dcmspec/iod_spec_builder.py
+++ b/src/dcmspec/iod_spec_builder.py
@@ -28,11 +28,14 @@ from dcmspec.progress import (
 # END LEGACY SUPPORT
 
 class IODSpecBuilder:
-    """Orchestrates the construction of a expanded DICOM IOD specification model.
+    """Orchestrates the construction of DICOM IOD specification models supporting two modes.
 
-    The IODSpecBuilder uses a factory to build the IOD Modules model and, for each referenced module,
-    uses a (possibly different) factory to build and cache the Module models. It then assembles a new
-    model with the IOD nodes and their referenced module nodes as children, and caches the expanded model.
+    - Expanded (legacy) mode: Produces a single expanded IOD model, where each IOD node has its referenced
+    Module's content nodes attached as children. This is the default if no module_registry is provided.
+
+    - Registry/reference mode: If a ModuleRegistry is provided, Module models are shared by reference via the registry,
+    enabling efficient reuse and reduced memory usage when building many IODs.
+
     """
 
     def __init__(
@@ -51,9 +54,9 @@ class IODSpecBuilder:
             iod_factory (Optional[SpecFactory]): Factory for building the IOD model. If None, uses SpecFactory().
             module_factory (Optional[SpecFactory]): Factory for building module models. If None, uses iod_factory.
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
-            ref_attr (Optional[str]): Attribute name to use for module references. If None, defaults to "ref".
-            module_registry (Optional[ModuleRegistry]): Registry for sharing module models by table_id.
-                If provided, module models are shared by reference across IODs.
+            ref_attr (Optional[str]): Attribute name to use for Module references. If None, defaults to "ref".
+            module_registry (Optional[ModuleRegistry]): Registry for sharing Module models by table_id.
+                If provided, Module models are shared by reference across IODs.
 
         Raises:
             ValueError: If `ref_attr` is not a non-empty string.

--- a/src/dcmspec/module_registry.py
+++ b/src/dcmspec/module_registry.py
@@ -1,0 +1,106 @@
+"""Module registry class for sharing module models across IODs in dcmspec.
+
+Provides the ModuleRegistry class, which manages a mapping from table_id to module SpecModel.
+This enables memory-efficient sharing of module models when building many IODs.
+
+A table_id is a string identifier for a DICOM table, typically extracted from the HTML anchor tag,
+for example: <a id="table_C.7-1" shape="rect"></a> yields table_id="table_C.7-1".
+"""
+
+from typing import Dict
+from dcmspec.spec_model import SpecModel
+
+class ModuleRegistry:
+    """Registry for sharing module models by table_id across IODs.
+
+    This class manages a mapping from table_id (str) to SpecModel.
+    The table_id is typically a string like "table_C.7-1", as found in the HTML anchor tag:
+        <a id="table_C.7-1" shape="rect"></a>
+    It is used to avoid duplicating module models in memory when building many IODs.
+
+    Example usage:
+        registry = ModuleRegistry()
+        # When building IODs, pass registry to IODSpecBuilder(module_registry=registry)
+
+        # Setting a module model:
+        registry["table_C.7-1"] = module_model
+
+        # Getting a module model:
+        model = registry["table_C.7-1"]
+
+        # Checking if a module is present:
+        if "table_C.7-1" in registry:
+            ...
+
+        # Iterating over all table_ids and models:
+        for table_id, model in registry.items():
+            ...
+    """
+
+    def __init__(self):
+        """Initialize an empty module registry."""
+        self._modules: Dict[str, SpecModel] = {}
+
+    def __contains__(self, table_id: str) -> bool:
+        """Return True if the registry contains a module for the given table_id.
+
+        Args:
+            table_id (str): The table ID to check (e.g., "table_C.7-1").
+
+        Returns:
+            bool: True if present, False otherwise.
+
+        """
+        return table_id in self._modules
+
+    def __getitem__(self, table_id: str) -> SpecModel:
+        """Get the module model for the given table_id.
+
+        Args:
+            table_id (str): The table ID of the module (e.g., "table_C.7-1").
+
+        Returns:
+            SpecModel: The module model.
+
+        Raises:
+            KeyError: If the table_id is not present.
+
+        """
+        return self._modules[table_id]
+
+    def __setitem__(self, table_id: str, model: SpecModel) -> None:
+        """Set the module model for the given table_id.
+
+        Args:
+            table_id (str): The table ID of the module (e.g., "table_C.7-1").
+            model (SpecModel): The module model to set.
+
+        """
+        self._modules[table_id] = model
+
+    def items(self):
+        """Return a set-like object providing a view on the registry's items.
+
+        Returns:
+            ItemsView: A view of (table_id, model) pairs.
+
+        """
+        return self._modules.items()
+
+    def keys(self):
+        """Return a set-like object providing a view on the registry's keys.
+
+        Returns:
+            KeysView: A view of table_ids.
+
+        """
+        return self._modules.keys()
+
+    def values(self):
+        """Return an object providing a view on the registry's values.
+
+        Returns:
+            ValuesView: A view of module models.
+
+        """
+        return self._modules.values()

--- a/src/dcmspec/module_registry.py
+++ b/src/dcmspec/module_registry.py
@@ -7,7 +7,8 @@ A table_id is a string identifier for a DICOM table, typically extracted from th
 for example: <a id="table_C.7-1" shape="rect"></a> yields table_id="table_C.7-1".
 """
 
-from typing import Dict
+from typing import Dict, ItemsView, KeysView, ValuesView
+
 from dcmspec.spec_model import SpecModel
 
 class ModuleRegistry:
@@ -18,7 +19,8 @@ class ModuleRegistry:
         <a id="table_C.7-1" shape="rect"></a>
     It is used to avoid duplicating module models in memory when building many IODs.
 
-    Example usage:
+    Example:
+        ```python
         registry = ModuleRegistry()
         # When building IODs, pass registry to IODSpecBuilder(module_registry=registry)
 
@@ -35,6 +37,8 @@ class ModuleRegistry:
         # Iterating over all table_ids and models:
         for table_id, model in registry.items():
             ...
+        ```
+        
     """
 
     def __init__(self):
@@ -78,29 +82,29 @@ class ModuleRegistry:
         """
         self._modules[table_id] = model
 
-    def items(self):
+    def items(self) -> ItemsView[str, SpecModel]:
         """Return a set-like object providing a view on the registry's items.
 
         Returns:
-            ItemsView: A view of (table_id, model) pairs.
+            ItemsView[str, SpecModel]: A view of (table_id, model) pairs.
 
         """
         return self._modules.items()
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
         """Return a set-like object providing a view on the registry's keys.
 
         Returns:
-            KeysView: A view of table_ids.
+            KeysView[str]: A view of table_ids.
 
         """
         return self._modules.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[SpecModel]:
         """Return an object providing a view on the registry's values.
 
         Returns:
-            ValuesView: A view of module models.
+            ValuesView[SpecModel]: A view of module models.
 
         """
         return self._modules.values()

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -404,11 +404,13 @@ class PDFDocHandler(DocHandler):
             dict: Mapping from note key (e.g., "Note 1:") to a dict with 'text' and 'table_id' (if provided).
 
         Example return:
+            ```json
             {
                 "Note 1:": {"text": "...", "table_id": "T-7.5-1"},
                 "Note 2:": {"text": "...", "table_id": "T-7.5-1"},
             }
-
+            ```
+            
         """
         import re
 

--- a/src/dcmspec/service_attribute_defaults.py
+++ b/src/dcmspec/service_attribute_defaults.py
@@ -19,23 +19,23 @@ Note:
 
     
 Example usage:
-```python
-from dcmspec.service_attribute_defaults import UPS_DIMSE_MAPPING, UPS_COLUMNS_MAPPING, UPS_NAME_ATTR
-factory = SpecFactory(
-    model_class=ServiceAttributeModel,
-    input_handler=UPSXHTMLDocHandler(),
-    column_to_attr=UPS_COLUMNS_MAPPING.copy(),
-    name_attr=UPS_NAME_ATTR,
-    config=config
-)
-model = factory.create_model(
-    url=url,
-    cache_file_name=cache_file_name,
-    table_id=table_id,
-    force_download=False,
-    model_kwargs={"dimse_mapping": copy.deepcopy(UPS_DIMSE_MAPPING)},
+    ```python
+    from dcmspec.service_attribute_defaults import UPS_DIMSE_MAPPING, UPS_COLUMNS_MAPPING, UPS_NAME_ATTR
+    factory = SpecFactory(
+        model_class=ServiceAttributeModel,
+        input_handler=UPSXHTMLDocHandler(),
+        column_to_attr=UPS_COLUMNS_MAPPING.copy(),
+        name_attr=UPS_NAME_ATTR,
+        config=config
     )
-```
+    model = factory.create_model(
+        url=url,
+        cache_file_name=cache_file_name,
+        table_id=table_id,
+        force_download=False,
+        model_kwargs={"dimse_mapping": copy.deepcopy(UPS_DIMSE_MAPPING)},
+        )
+    ```
 
 """
 

--- a/src/dcmspec/service_attribute_model.py
+++ b/src/dcmspec/service_attribute_model.py
@@ -32,22 +32,6 @@ class ServiceAttributeModel(SpecModel):
 
         Sets up the model with metadata, content, and a DIMSE mapping for filtering.
         Initializes the DIMSE and role selection to None.
-
-        The `dimse_mapping` argument should be a dictionary with the following structure:
-
-        ```python
-        {
-            "ALL_DIMSE": {
-                "attributes": [<attribute_name>, ...]
-            },
-            "<DIMSE>": {
-                "attributes": [<attribute_name>, ...],
-                "req_attributes": [<attribute_name>, ...],  # optional, for role-based requirements
-                "req_separator": "<separator>",             # optional, e.g. "/"
-            },
-            ...
-        }
-        ```
             
         Args:
             metadata (Node): Node holding table and document metadata.
@@ -55,6 +39,21 @@ class ServiceAttributeModel(SpecModel):
             dimse_mapping (dict): Dictionary defining DIMSE and role-based attribute requirements.
             logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
 
+        Note:
+            The `dimse_mapping` argument should be a dictionary with the following structure:
+            ```python
+            {
+                "ALL_DIMSE": {
+                    "attributes": [<attribute_name>, ...]
+                },
+                "<DIMSE>": {
+                    "attributes": [<attribute_name>, ...],
+                    "req_attributes": [<attribute_name>, ...],  # optional, for role-based requirements
+                    "req_separator": "<separator>",             # optional, e.g. "/"
+                },
+                ...
+            }
+            ```
 
         Example:
             ```python

--- a/src/dcmspec/spec_factory.py
+++ b/src/dcmspec/spec_factory.py
@@ -30,8 +30,11 @@ class SpecFactory:
     Supports flexible configuration and caching strategies.
 
     Typical usage:
+        ```python
         factory = SpecFactory(...)
         model = factory.create_model(...)
+        ```
+        
     """
 
     def __init__(

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -58,13 +58,16 @@ class SpecPrinter:
                 If provided, each attribute will be padded/truncated to the specified width.
             colorize (bool): Whether to colorize the output by node depth.
 
-        Example:
-            # This will nicely align the tag, type, and name values in the tree output:
-            printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64])
-
         Returns:
             None
 
+        
+        Example:
+            ```python
+            # This will nicely align the tag, type, and name values in the tree output:
+            printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64])
+            ```
+            
         """
         for pre, fill, node in RenderTree(self.model.content):
             style = LEVEL_COLORS[node.depth % len(LEVEL_COLORS)] if colorize else "default"

--- a/tests/test_iod_spec_builder.py
+++ b/tests/test_iod_spec_builder.py
@@ -4,13 +4,32 @@ from anytree import Node
 from dcmspec.iod_spec_builder import IODSpecBuilder
 from dcmspec.progress import Progress, ProgressStatus
 from dcmspec.spec_model import SpecModel
+from dcmspec.module_registry import ModuleRegistry
+
+@pytest.fixture(autouse=True)
+def patch_get_table_id_from_section(monkeypatch):
+    """Automatically patch get_table_id_from_section for all tests in this module."""
+    def get_table_id_from_section(self, dom, section_id):
+        if "PATIENT" in section_id:
+            return "table_PATIENT"
+        elif "STUDY" in section_id:
+            return "table_STUDY"
+        return None
+    # Patch for all tests in this module
+    monkeypatch.setattr("dcmspec.iod_spec_builder.DOMUtils.get_table_id_from_section", get_table_id_from_section)
+
 
 class DummyFactory:
     """A dummy factory that returns a fixed model for build_model and load_dom."""
 
-    def __init__(self):
-        """Initialize."""
+    def __init__(self, ref_value="PATIENT"):
+        """Initialize with a configurable ref_value or list of ref_values for the IOD node(s)."""
         self.called = []
+        # Accept either a single ref_value or a list of ref_values
+        if isinstance(ref_value, (list, tuple)):
+            self.ref_values = list(ref_value)
+        else:
+            self.ref_values = [ref_value]
 
     def load_document(self, url, cache_file_name, force_download=False, progress_observer=None, progress_callback=None):
         """Patch loading the document.
@@ -28,25 +47,25 @@ class DummyFactory:
         return "FAKE_DOM"
 
     def build_model(self, doc_object, table_id, url, json_file_name, **kwargs):
-        """Patch building the model."""
+        """Patch building the model with configurable referenced modules."""
         self.called.append(("build_model", doc_object, table_id, url, json_file_name))
         metadata = self._create_metadata_node()
-        content = Node("content")
-        # Add a node with a ref attribute
-        iod_node = Node("iod_node", parent=content)
-        setattr(iod_node, "ref", "PATIENT")
-        # Add a dummy module node for the referenced module
-        module_content = Node("content")
-        module_attr = Node("attr", parent=module_content)
-        setattr(module_attr, "attr1", "Value1")
-        setattr(module_attr, "attr2", "Value2")
-        module_metadata = self._create_metadata_node()
-        module_model = SpecModel(metadata=module_metadata, content=module_content)
-        # Return a model with a content node and a referenced module node
+        # sourcery skip: extract-method, remove-unnecessary-else, swap-if-else-branches
         if table_id == "table_IOD":
+            content = Node("content")
+            # Add nodes with ref attributes from self.ref_values
+            for ref in self.ref_values:
+                module_node = Node(f"module_node_{ref}", parent=content)
+                setattr(module_node, "ref", ref)
             return SpecModel(metadata=metadata, content=content)
         else:
-            return module_model
+            # Build a module model (for any referenced module)
+            module_content = Node("content")
+            module_attr = Node("attr", parent=module_content)
+            setattr(module_attr, "attr1", "Value1")
+            setattr(module_attr, "attr2", "Value2")
+            module_metadata = self._create_metadata_node()
+            return SpecModel(metadata=module_metadata, content=module_content)
 
     def _create_metadata_node(self):
         # Create a dummy metadata node
@@ -125,10 +144,49 @@ class DummyModelStore:
         """Record the model and path in the self.saved dict."""
         self.saved["model"] = model
         self.saved["path"] = path
-        
-def test_iod_spec_builder_combines_iod_and_module(monkeypatch):
+
+class CustomModelStore(DummyModelStore):
+    """A dummy ModelStore that returns specific models based on path."""
+
+    def __init__(self, iod_model, module_models: dict):
+        """Initialize with specific models to return."""
+        super().__init__()
+        self._iod_model = iod_model
+        self._module_models = module_models  # dict: table_id -> module_model
+
+    def load(self, path):
+        """Return the iod_model or the correct module_model based on path."""
+        if path.endswith("dummy.json"):
+            return self._iod_model
+        for table_id, module_model in self._module_models.items():
+            if path.endswith(f"{table_id}.json"):
+                return module_model
+        return super().load(path)
+    
+class RegistryOnlyModelStore(DummyModelStore):
+    """Dummy ModelStore that raises if asked to load a module model from cache.
+
+    Ensuring that the registry is used for module models.
+    """
+    
+    def __init__(self, iod_model, forbidden_table_ids=None):
+        """Initialize with specific iod_model and forbidden table_ids."""
+        super().__init__()
+        self._iod_model = iod_model
+        self._forbidden_table_ids = forbidden_table_ids or []
+
+    def load(self, path):
+        """Return the iod_model or raise if a forbidden module is requested."""
+        if path.endswith("dummy.json"):
+            return self._iod_model
+        for table_id in self._forbidden_table_ids:
+            if path.endswith(f"{table_id}.json"):
+                raise AssertionError(f"Should not load module {table_id} from cache when registry is present")
+        return super().load(path)
+
+def test_iod_spec_builder_combines_iod_and_module():
     """Test IODSpecBuilder combines IOD and module models correctly."""
-    factory = DummyFactory()
+    factory = DummyFactory(ref_value=["PATIENT", "STUDY"])
     # Patch table_parser on the factory to our dummy
     factory.table_parser = factory
     # Add a dummy config for cache_dir to support module cache loading
@@ -137,23 +195,117 @@ def test_iod_spec_builder_combines_iod_and_module(monkeypatch):
     factory.model_store = DummyModelStore()
     builder = IODSpecBuilder(iod_factory=factory, module_factory=factory)
 
-    # Patch DOMUtils.get_table_id_from_section to always return "table_PATIENT"
-    monkeypatch.setattr(builder.dom_utils, "get_table_id_from_section", lambda dom, section_id: "table_PATIENT")
-
-    model = builder.build_from_url(
+    model, _ = builder.build_from_url(
         url="http://example.com",
         cache_file_name="file.xhtml",
         table_id="table_IOD",
         force_download=False,
         json_file_name=None,
     )
-    # The expanded model should have a content node with the iod_node and the module's attr as children
-    iod_node = next(iter(model.content.children))
-    assert getattr(iod_node, "ref", None) == "PATIENT"
-    # The module's attribute node should be a child of the iod_node
-    module_attr = next(iter(iod_node.children))
-    assert getattr(module_attr, "attr1", None) == "Value1"
-    assert getattr(module_attr, "attr2", None) == "Value2"
+    # The expanded model should have a content node with the iod_nodes and the module's attr as children
+    iod_nodes = list(model.content.children)
+    refs = [getattr(node, "ref", None) for node in iod_nodes]
+    assert "PATIENT" in refs
+    assert "STUDY" in refs
+    # For each iod_node, check that the module's attribute node is a child of the iod_node
+    assert all(
+        any(
+            getattr(module_attr, "attr1", None) == "Value1" and
+            getattr(module_attr, "attr2", None) == "Value2"
+            for module_attr in iod_node.children
+        )
+        for iod_node in iod_nodes
+    )
+
+def test_iod_spec_builder_registry_mode():
+    """Test IODSpecBuilder in registry/reference mode shares module models via ModuleRegistry."""
+    factory = DummyFactory(ref_value=["PATIENT", "STUDY"])
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir="cache")
+    factory.model_store = DummyModelStore()
+    registry = ModuleRegistry()
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory, module_registry=registry)
+
+    iod_model, module_models = builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name=None,
+    )
+    # The IOD model should not be expanded, but should have table_id set on the iod_nodes
+    iod_nodes = list(iod_model.content.children)
+    refs = [getattr(node, "ref", None) for node in iod_nodes]
+    assert "PATIENT" in refs
+    assert "STUDY" in refs
+    # The module_models dict should be keyed by table_id and contain both module models
+    assert "table_PATIENT" in module_models
+    assert "table_STUDY" in module_models
+    # The registry should also contain both module models
+    assert "table_PATIENT" in registry
+    assert "table_STUDY" in registry
+    assert registry["table_PATIENT"] is module_models["table_PATIENT"]
+    assert registry["table_STUDY"] is module_models["table_STUDY"]
+    # The module's attribute node should be present in each module model
+    assert all(
+        any(
+            getattr(module_attr, "attr1", None) == "Value1" and
+            getattr(module_attr, "attr2", None) == "Value2"
+            for module_attr in module_models[table_id].content.children
+        )
+        for table_id in ["table_PATIENT", "table_STUDY"]
+    )
+
+def test_build_from_url_normalizes_plain_text_ref(monkeypatch):
+    """Test build_from_url normalizes plain text ref to sect_... and passes to get_table_id_from_section."""
+    factory = DummyFactory(ref_value="C.7.1.1")
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir="cache")
+    factory.model_store = DummyModelStore()
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory)
+
+    # Patch DOMUtils.get_table_id_from_section to record calls
+    called_section_ids = []
+    def fake_get_table_id_from_section(dom, section_id):
+        called_section_ids.append(section_id)
+        return "table_PATIENT"
+    monkeypatch.setattr(builder.dom_utils, "get_table_id_from_section", fake_get_table_id_from_section)
+
+    builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name=None,
+    )
+    # Should have called get_table_id_from_section with normalized plain text
+    assert "sect_C.7.1.1" in called_section_ids
+
+def test_build_from_url_normalizes_html_anchor_ref(monkeypatch):
+    """Test build_from_url normalizes HTML anchor ref and passes to get_table_id_from_section."""
+    html_anchor = '<a class="xref" href="#sect_C.7.1.1">Patient Module</a>'
+    factory = DummyFactory(ref_value=html_anchor)
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir="cache")
+    factory.model_store = DummyModelStore()
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory)
+
+    # Patch DOMUtils.get_table_id_from_section to record calls
+    called_section_ids = []
+    def fake_get_table_id_from_section(dom, section_id):
+        called_section_ids.append(section_id)
+        return "table_PATIENT"
+    monkeypatch.setattr(builder.dom_utils, "get_table_id_from_section", fake_get_table_id_from_section)
+
+    builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name=None,
+    )
+    # Should have called get_table_id_from_section with normalized HTML anchor
+    assert "sect_C.7.1.1" in called_section_ids
 
 def test_iod_spec_builder_custom_ref_attr(monkeypatch):
     """Test IODSpecBuilder works with a custom reference attribute name using DummyFactory."""
@@ -165,7 +317,7 @@ def test_iod_spec_builder_custom_ref_attr(monkeypatch):
     builder = IODSpecBuilder(iod_factory=factory, module_factory=factory, ref_attr="reference")
     monkeypatch.setattr(builder.dom_utils, "get_table_id_from_section", lambda dom, section_id: "table_PATIENT")
 
-    model = builder.build_from_url(
+    model, _ = builder.build_from_url(
         url="http://example.com",
         cache_file_name="file.xhtml",
         table_id="table_IOD",
@@ -182,6 +334,8 @@ def test_iod_spec_builder_no_referenced_modules(monkeypatch):
     """Test IODSpecBuilder raises if no referenced modules are found."""
     factory = NoRefFactory()
     factory.table_parser = factory
+    # Add a dummy config for cache_dir to support module cache loading
+    factory.config = DummyConfig(cache_dir="cache")
     builder = IODSpecBuilder(iod_factory=factory, module_factory=factory)
     with pytest.raises(RuntimeError, match="No module models were found"):
         builder.build_from_url(
@@ -227,7 +381,7 @@ def test_iod_spec_builder_saves_expanded_model(monkeypatch, tmp_path):
     # Patch os.path.exists to always return False (force build, not cache)
     monkeypatch.setattr("os.path.exists", lambda path: False)
 
-    model = builder.build_from_url(
+    model, _ = builder.build_from_url(
         url="http://example.com",
         cache_file_name="file.xhtml",
         table_id="table_IOD",
@@ -262,7 +416,7 @@ def test_iod_spec_builder_save_failure_logs_warning(monkeypatch, tmp_path, caplo
     monkeypatch.setattr("os.path.exists", lambda path: False)
 
     with caplog.at_level("WARNING"):
-        model = builder.build_from_url(
+        model, _ = builder.build_from_url(
             url="http://example.com",
             cache_file_name="file.xhtml",
             table_id="table_IOD",
@@ -272,7 +426,7 @@ def test_iod_spec_builder_save_failure_logs_warning(monkeypatch, tmp_path, caplo
     # The model should still be returned
     assert isinstance(model, SpecModel)
     # The warning should be logged
-    assert "Failed to cache expanded model to" in caplog.text
+    assert "Failed to cache model to" in caplog.text
     assert "Simulated save failure" in caplog.text
 
 def test_iod_spec_builder_no_save_when_no_json_file(monkeypatch, tmp_path, caplog):
@@ -291,7 +445,7 @@ def test_iod_spec_builder_no_save_when_no_json_file(monkeypatch, tmp_path, caplo
     monkeypatch.setattr("os.path.exists", lambda path: False)
 
     with caplog.at_level("INFO"):
-        model = builder.build_from_url(
+        model, _ = builder.build_from_url(
             url="http://example.com",
             cache_file_name="file.xhtml",
             table_id="table_IOD",
@@ -318,7 +472,7 @@ def test_iod_spec_builder_load_cache_success(monkeypatch, tmp_path):
     # Patch model_store.load to return a dummy model
     factory.model_store = DummyModelStore()
     builder.iod_factory.model_store = factory.model_store
-    result = builder.build_from_url(
+    model, _ = builder.build_from_url(
         url="http://example.com",
         cache_file_name="file.xhtml",
         table_id="table_IOD",
@@ -326,8 +480,154 @@ def test_iod_spec_builder_load_cache_success(monkeypatch, tmp_path):
         json_file_name="dummy.json",
     )
     # The result should be a SpecModel loaded from cache
-    assert isinstance(result, SpecModel)
-    assert result is factory.model_store.load("dummy.json")
+    assert isinstance(model, SpecModel)
+    assert model is factory.model_store.load("dummy.json")
+
+def test_iod_spec_builder_load_cache_with_registry(monkeypatch, tmp_path):
+    """Test IODSpecBuilder loads from cache when a registry is passed as arg, with two modules."""
+    factory = DummyFactory()
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir=str(tmp_path))
+
+    # Prepare dummy IOD and module models
+    iod_model = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    module_model_patient = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    module_model_study = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    # Add two module nodes to the IOD model
+    # sourcery skip: extract-duplicate-method
+    iod_node_patient = Node("iod_node_patient", parent=iod_model.content)
+    setattr(iod_node_patient, "ref", "PATIENT")
+    setattr(iod_node_patient, "table_id", "table_PATIENT")
+    iod_node_study = Node("iod_node_study", parent=iod_model.content)
+    setattr(iod_node_study, "ref", "STUDY")
+    setattr(iod_node_study, "table_id", "table_STUDY")
+
+    # CustomModelStore returns the correct module model for each table
+    module_models_dict = {
+        "table_PATIENT": module_model_patient,
+        "table_STUDY": module_model_study,
+    }
+    factory.model_store = CustomModelStore(iod_model, module_models_dict)
+
+    registry = ModuleRegistry()
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory, module_registry=registry)
+    builder.iod_factory.model_store = factory.model_store
+    builder.module_factory.model_store = factory.model_store
+
+    # Patch os.path.exists to always return True
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+
+    model, module_models = builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name="dummy.json",
+    )
+    # The result should be a SpecModel loaded from cache
+    assert isinstance(model, SpecModel)
+    assert model is iod_model
+    # The module_models dict should be present and contain both cached module models
+    assert module_models is not None
+    assert "table_PATIENT" in module_models
+    assert "table_STUDY" in module_models
+    assert module_models["table_PATIENT"] is module_model_patient
+    assert module_models["table_STUDY"] is module_model_study
+    # The registry should also contain both module models
+    assert "table_PATIENT" in registry
+    assert "table_STUDY" in registry
+    assert registry["table_PATIENT"] is module_model_patient
+    assert registry["table_STUDY"] is module_model_study
+
+def test_iod_spec_builder_load_iod_cache_and_reuse_module_from_registry(monkeypatch, tmp_path):
+    """Test IODSpecBuilder loads IOD from cache and reuses modules from registry."""
+    factory = DummyFactory()
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir=str(tmp_path))
+
+    # Prepare dummy IOD and module models
+    iod_model = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    module_model_patient = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    module_model_study = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    # Add two module nodes to the IOD model
+    # sourcery skip: extract-duplicate-method
+    iod_node_patient = Node("iod_node_patient", parent=iod_model.content)
+    setattr(iod_node_patient, "ref", "PATIENT")
+    setattr(iod_node_patient, "table_id", "table_PATIENT")
+    iod_node_study = Node("iod_node_study", parent=iod_model.content)
+    setattr(iod_node_study, "ref", "STUDY")
+    setattr(iod_node_study, "table_id", "table_STUDY")
+
+    # Pre-populate the registry with both module models
+    registry = ModuleRegistry()
+    registry["table_PATIENT"] = module_model_patient
+    registry["table_STUDY"] = module_model_study
+
+    # Use RegistryOnlyModelStore to ensure cache is not used for modules
+    factory.model_store = RegistryOnlyModelStore(iod_model, forbidden_table_ids=["table_PATIENT", "table_STUDY"])
+
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory, module_registry=registry)
+    builder.iod_factory.model_store = factory.model_store
+    builder.module_factory.model_store = factory.model_store
+
+    # Patch os.path.exists to always return True
+    monkeypatch.setattr("os.path.exists", lambda path: True)
+
+    model, module_models = builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name="dummy.json",
+    )
+    # The result should be a SpecModel loaded from cache
+    assert isinstance(model, SpecModel)
+    assert model is iod_model
+    # The module_models dict should be present and contain the registry module models
+    assert module_models is not None
+    assert "table_PATIENT" in module_models
+    assert "table_STUDY" in module_models
+    assert module_models["table_PATIENT"] is module_model_patient
+    assert module_models["table_STUDY"] is module_model_study
+    # The registry should also contain both module models
+    assert "table_PATIENT" in registry
+    assert "table_STUDY" in registry
+    assert registry["table_PATIENT"] is module_model_patient
+    assert registry["table_STUDY"] is module_model_study
+
+def test_iod_spec_builder_registry_reuse():
+    """Test that IODSpecBuilder reuses one module from registry and builds the other."""
+    factory = DummyFactory(ref_value=["PATIENT", "STUDY"])
+    factory.table_parser = factory
+    factory.config = DummyConfig(cache_dir="cache")
+    factory.model_store = DummyModelStore()
+    registry = ModuleRegistry()
+
+    # Pre-populate the registry with only PATIENT
+    module_model_patient = SpecModel(metadata=Node("metadata"), content=Node("content"))
+    registry["table_PATIENT"] = module_model_patient
+
+    builder = IODSpecBuilder(iod_factory=factory, module_factory=factory, module_registry=registry)
+
+    iod_model, module_models = builder.build_from_url(
+        url="http://example.com",
+        cache_file_name="file.xhtml",
+        table_id="table_IOD",
+        force_download=False,
+        json_file_name=None,
+    )
+    # The module_models dict should be present and contain both modules
+    assert module_models is not None
+    assert "table_PATIENT" in module_models
+    assert "table_STUDY" in module_models
+    # PATIENT should be reused from registry, STUDY should be freshly built
+    assert module_models["table_PATIENT"] is module_model_patient
+    assert registry["table_PATIENT"] is module_model_patient
+    assert registry["table_STUDY"] is module_models["table_STUDY"]
+    # STUDY should be a SpecModel instance
+    assert isinstance(module_models["table_STUDY"], SpecModel)
+    # The two module models should not be the same object
+    assert module_models["table_PATIENT"] is not module_models["table_STUDY"]
 
 def test_iod_spec_builder_load_cache_failure(monkeypatch, tmp_path, caplog):
     """Test IODSpecBuilder logs a warning if loading the cached model or a module model fails."""
@@ -349,7 +649,7 @@ def test_iod_spec_builder_load_cache_failure(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr("os.path.exists", lambda path: True)
 
     with caplog.at_level("WARNING"):
-        model = builder.build_from_url(
+        model, _ = builder.build_from_url(
             url="http://example.com",
             cache_file_name="file.xhtml",
             table_id="table_IOD",
@@ -359,7 +659,7 @@ def test_iod_spec_builder_load_cache_failure(monkeypatch, tmp_path, caplog):
     # The model should still be returned (built, not loaded)
     assert isinstance(model, SpecModel)
     # The warnings for both expanded IOD and Module model should be logged
-    assert "Failed to load expanded IOD model from cache" in caplog.text
+    assert "Failed to load IOD model from cache" in caplog.text
     assert "Failed to load module model from cache" in caplog.text
     assert "Simulated load failure" in caplog.text
 

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,0 +1,29 @@
+"""Tests for the ModuleRegistry class in dcmspec.module_registry."""
+from dcmspec.module_registry import ModuleRegistry
+from dcmspec.spec_model import SpecModel
+from anytree import Node
+
+def test_module_registry_basic_usage():
+    """Test basic usage of ModuleRegistry: set, get, contains, keys, values, items."""
+    registry = ModuleRegistry()
+    model1 = SpecModel(metadata=Node("metadata1"), content=Node("content1"))
+    model2 = SpecModel(metadata=Node("metadata2"), content=Node("content2"))
+
+    # Test setitem and getitem
+    registry["table_A"] = model1
+    registry["table_B"] = model2
+    assert registry["table_A"] is model1
+    assert registry["table_B"] is model2
+
+    # Test contains
+    assert "table_A" in registry
+    assert "table_B" in registry
+    assert "table_C" not in registry
+
+    # Test keys, values, items
+    keys = set(registry.keys())
+    assert keys == {"table_A", "table_B"}
+    values = set(registry.values())
+    assert values == {model1, model2}
+    items = dict(registry.items())
+    assert items == {"table_A": model1, "table_B": model2}


### PR DESCRIPTION
Add a mode to create IOD models with references to Modules models in a registry instead of expanding the Modules in the model.

## Summary by Sourcery

Implement a new registry mode in IODSpecBuilder backed by a ModuleRegistry to share module models by reference, introduce a breaking API change where build_from_url returns both the IOD model and module models, refactor caching and module loading logic, update all callers (CLI, UI) accordingly, enhance reference normalization, bump version to 0.2.0, and update documentation with release notes, code samples, and changelog.

New Features:
- Add ModuleRegistry class for sharing module SpecModel instances across IOD builds
- Introduce registry/reference mode in IODSpecBuilder to return module models by reference instead of expanding them
- Change IODSpecBuilder.build_from_url to return a tuple (iod_model, module_models) instead of a single model

Enhancements:
- Refactor IODSpecBuilder to separate IOD and module cache loading and to consolidate module model building into helper methods
- Normalize plain text and HTML anchor references before resolving table IDs
- Update CLI and GUI applications to unpack the new build_from_url return value

Documentation:
- Add release notes and bump project version to 0.2.0
- Enhanced code examples with proper markdown fences in multiple modules (dom_utils, spec_printer, service_attribute_defaults, spec_factory)
- Update README, docs index, mkdocs config, and API navigation to include release notes and ModuleRegistry documentation
- Add changelog and API documentation page for ModuleRegistry

Tests:
- Expand test suite to cover registry mode, caching behaviors, reference normalization, and error paths in IODSpecBuilder
- Add tests for ModuleRegistry basic operations (set, get, contains, iteration)