### PR TITLE
Fix doc github action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
           cache-poetry: "true"
 
       - name: Install dependencies
-        run: poetry install --with docs --without test
+        run: poetry install --with dev
 
       - name: Build docs
         run: poetry run mkdocs build --clean


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change Poetry install command in doc workflow to use 'poetry install --with dev' instead of only docs dependencies