### PR TITLE
Change/tune log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These release notes summarize key changes, improvements, and breaking updates fo
 - Replace Unicode ▶ with ASCII > in status bar for compatibility
 - Improve DICOM Modules usage condition parsing using regex for robustness to missing spaces
 - Add PR template to remind contributors to check the target branch and check tests and docs were updated
+- Move detailed table parsing logs to DEBUG level for less verbose INFO output
 
 ## [0.2.1] - 2025-09-19
 

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -161,7 +161,7 @@ class DOMTableSpecParser(SpecParser):
             root: The root node of the tree representation of the specification table.
 
         """
-        self.logger.info(f"Nesting Level: {table_nesting_level}, Parsing table with id {table_id}")
+        self.logger.debug(f"Nesting Level: {table_nesting_level}, Parsing table with id {table_id}")
 
         if unformatted_list is None:
             num_columns = max(column_to_attr.keys()) + 1
@@ -208,7 +208,7 @@ class DOMTableSpecParser(SpecParser):
                 progress_observer=progress_observer if table_nesting_level == 0 else None,
             )
 
-            self.logger.info(f"Nesting Level: {table_nesting_level}, Table parsed successfully")
+            self.logger.debug(f"Nesting Level: {table_nesting_level}, Table parsed successfully")
 
             return root
 
@@ -777,7 +777,7 @@ class DOMTableSpecParser(SpecParser):
             for col_idx in column_to_attr
             if col_idx < len(cells)
         )
-        self.logger.info(f"Extracted Header: {header}")
+        self.logger.debug(f"Extracted Header: {header}")
         return header
 
     def _clean_extracted_text(self, text: str) -> str:


### PR DESCRIPTION
## Summary by Sourcery

Tune log verbosity by moving detailed table parsing logs to DEBUG level and document the change in the changelog

Enhancements:
- Change detailed table parsing log messages from INFO to DEBUG to reduce verbosity

Documentation:
- Update CHANGELOG.md to note the log level adjustment