### PR TITLE
Fail loudly when a data row is absorbed into a table header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 These release notes summarize key changes, improvements, and breaking updates for each version of **dcmspec**.
 
-## [0.3.0] - unreleased
+## [0.3.0] - 2025-11-23
 
 ### Added
 - CSV output mode in `SpecPrinter` via `print_csv` method
-- New CLI option `--print-mode csv` in `modattributes` script for CSV output
+- Optional `output` parameter in `SpecPrinter` for writing to files
+- `--print-mode` option in `modattributes` CLI for CSV output
+- `--output` option in `modattributes` CLI for directing output to files
 
 ### Fixed
 
-- N/A
+- Correct handling of `include_table` names in DOM table spec parser
 
 ## [0.2.3] - 2025-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ These release notes summarize key changes, improvements, and breaking updates fo
 ## [0.3.0] - 2025-11-23
 
 ### Added
+
 - CSV output mode in `SpecPrinter` via `print_csv` method
 - Optional `output` parameter in `SpecPrinter` for writing to files
 - `--print-mode` option in `modattributes` CLI for CSV output
 - `--output` option in `modattributes` CLI for directing output to files
+
+### Changed
+
+- Switch PyPI version badge in `README` from `badge.fury.io` to `shields.io` for faster updates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 These release notes summarize key changes, improvements, and breaking updates for each version of **dcmspec**.
 
-## [0.3.0] - 2025-11-25
+## [0.3.0] - 2025-11-27
 
 ### Added
 
@@ -17,6 +17,7 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 - Switch PyPI version badge in `README` from `badge.fury.io` to `shields.io` for faster updates
 - Update modattributes CLI example for CSV and XLSX output
+- Improved nesting level color schemes for consistency and better contrast and readability.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 ## [0.3.0] - unreleased
 
+### Added
+- CSV output mode in `SpecPrinter` via `print_csv` method
+- New CLI option `--print-mode csv` in `modattributes` script for CSV output
+
 ### Fixed
 
-- Some fix.
-
-### Changed
-
-- Some new feature.
+- N/A
 
 ## [0.2.3] - 2025-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 - CSV output mode in `SpecPrinter` via `print_csv` method
 - Optional `output` parameter in `SpecPrinter` for writing to files
+- Optional `column_width` parameter in `print_table`
 - `--print-mode` option in `modattributes` CLI for CSV output
 - `--output` option in `modattributes` CLI for directing output to files
 
@@ -17,7 +18,8 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 ### Fixed
 
-- Correct handling of `include_table` names in DOM table spec parser
+- Correct handling of `include_table` names in `DOMTableSpecParser`
+- Correct handling of empty node attributes in `SpecPrinter`
 
 ## [0.2.3] - 2025-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 These release notes summarize key changes, improvements, and breaking updates for each version of **dcmspec**.
 
+## [0.3.0] - unreleased
+
+### Fixed
+
+- Some fix.
+
+### Changed
+
+- Some new feature.
+
 ## [0.2.3] - 2025-09-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,21 @@
 
 These release notes summarize key changes, improvements, and breaking updates for each version of **dcmspec**.
 
-## [0.3.0] - 2025-11-23
+## [0.3.0] - 2025-11-25
 
 ### Added
 
 - CSV output mode in `SpecPrinter` via `print_csv` method
+- Excel OOXML output mode in `SpecPrinter` via `print_xlsx` method
 - Optional `output` parameter in `SpecPrinter` for writing to files
-- Optional `column_width` parameter in `print_table`
-- `--print-mode` option in `modattributes` CLI for CSV output
+- Optional `column_width` parameter in `print_table` and `print_xlsx`
+- `--print-mode` option in `modattributes` CLI for CSV and OOXML output
 - `--output` option in `modattributes` CLI for directing output to files
 
 ### Changed
 
 - Switch PyPI version badge in `README` from `badge.fury.io` to `shields.io` for faster updates
+- Update modattributes CLI example for CSV and XLSX output
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 ### Changed
 
-- Switch PyPI version badge in `README` from `badge.fury.io` to `shields.io` for faster updates.
+- Switch PyPI version badge in `README` from `badge.fury.io` to `shields.io` for faster updates
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![tests](https://github.com/dwikler/dcmspec/actions/workflows/test.yml/badge.svg)](https://github.com/dwikler/dcmspec/actions/workflows/test.yml)
-[![PyPI version](https://badge.fury.io/py/dcmspec.svg)](https://badge.fury.io/py/dcmspec)
+[![PyPI version](https://img.shields.io/pypi/v/dcmspec.svg)](https://pypi.org/project/dcmspec/)
 [![Python versions](https://img.shields.io/pypi/pyversions/dcmspec.svg)](https://pypi.org/project/dcmspec/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17233195.svg)](https://doi.org/10.5281/zenodo.17233195)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![tests](https://github.com/dwikler/dcmspec/actions/workflows/test.yml/badge.svg)](https://github.com/dwikler/dcmspec/actions/workflows/test.yml)
 [![PyPI version](https://img.shields.io/pypi/v/dcmspec.svg)](https://pypi.org/project/dcmspec/)
 [![Python versions](https://img.shields.io/pypi/pyversions/dcmspec.svg)](https://pypi.org/project/dcmspec/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17233195.svg)](https://doi.org/10.5281/zenodo.17233195)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17742287.svg)](https://doi.org/10.5281/zenodo.17742287)
 
 # dcmspec
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,8 +53,17 @@ gitGraph
 > **Note:** This checklist is intended for project maintainers and developers.
 > It is not required for users of the dcmspec library.
 
-1. [ ] Update `pyproject.toml` with the new version number.
-2. [ ] Add a new section to `CHANGELOG.md` for the release:
+1. [ ] Create a new branch from the target release branch (e.g., `release/x.y.z`) for making changes:
+
+   ```bash
+   git checkout release/x.y.z
+   git pull origin release/x.y.z
+   git checkout -b docs/update-release-x.y.z
+   ```
+
+2. [ ] Update `pyproject.toml` with the new version number.
+
+3. [ ] Add a new section to `CHANGELOG.md` for the release:
 
    - Use the format:
 
@@ -73,53 +82,76 @@ gitGraph
 
 - Use **"Added"** for new features, **"Changed"** for enhancements or improvements, and **"Fixed"** for bug fixes.
 
-3. [ ] Commit the changes:
+4. [ ] Commit the changes in the branch:
 
    ```bash
-   git add pyproject.toml CHANGELOG.md docs/changelog.md
+   git add pyproject.toml CHANGELOG.md
    git commit -m "Bump version to x.y.z and update CHANGELOG"
+   git push origin docs/update-release-x.y.z
    ```
 
-4. [ ] Tag the release:
+5. [ ] Open a Pull Request to merge the branch into `release/x.y.z`.
 
-   Choose the appropriate command below based on the main type of change in this release.
+6. [ ] After merging, open a Pull Request to merge `release/x.y.z` into `main`.
+
+7. [ ] Tag the release **in GitHub after the merge to `main`** (do not use `git tag` locally to ensure the tag is verified):
+
+   - Choose the appropriate title based on the main type of change in this release.
 
    For a new feature:
 
-   ```bash
-   git tag -a vX.Y.Z -m "Add support for ... (#NN)"
+   ```
+   vX.Y.Z - Add support for ... (#NN)
    ```
 
    For an enhancement:
 
-   ```bash
-   git tag -a vX.Y.Z -m "Improve ... (#NN)"
+   ```
+   vX.Y.Z - Improve ... (#NN)
    ```
 
    For a bug fix:
 
-   ```bash
-   git tag -a vX.Y.Z -m "Corrected ... (#NN)"
+   ```
+   vX.Y.Z - Corrected ... (#NN)
    ```
 
-5. [ ] Push commits and tags:
-
-   ```bash
-   git push
-   git push --tags
-   ```
-
-6. [ ] Create a GitHub Release for the new tag:
+8. [ ] Create a GitHub Release for the new tag:
 
    - Copy the changelog entry into the release notes.
 
-7. [ ] [Build and test the distribution locally before publishing](#how-to-test-the-distribution-before-publishing)
+9. [ ] Update Zenodo badge:
 
-8. [ ] Publish to PyPI:
+   - Go to Zenodo and copy the new DOI for the release. Check the DOI link resolves to Zenodo by clicking the badge.
+     - **Tip:** Zenodo shows the next version-specific DOI next to the “Create new release” button.
+       This is the DOI that will be assigned when Zenodo archives your GitHub release.
+       You can use it in advance and wait until the new badge is active before publishing to PyPI.
+     - **Alternative:** Use the concept DOI instead of the version DOI if you want a badge that never needs updating and always points to the latest version.
+   - Create a new branch from `main` (e.g., `docs/update-zenodo-badge`).
+   - Update the badge number in `README`.
+   - Commit and push:
+     ```bash
+     git add README.md
+     git commit -m "Update Zenodo badge for vX.Y.Z"
+     git push origin docs/update-zenodo-badge
+     ```
+   - Open a Pull Request to merge into `main`.
 
-   ```bash
-   poetry publish --build
-   ```
+10. [ ] Switch to `main` and pull the latest commits and tags:
+
+```bash
+git checkout main
+git pull origin main --tags
+git describe --tags  # Verify you are on the correct tag
+```
+
+11. [ ] [Build and test the distribution locally before publishing](#how-to-test-the-distribution-before-publishing)
+
+12. [ ] Publish to PyPI:
+
+```bash
+poetry publish --build
+```
 
 ---
 

--- a/docs/apps/cli/iodattributes.md
+++ b/docs/apps/cli/iodattributes.md
@@ -39,7 +39,7 @@ For more information on configuration and caching location see the [Configuratio
 - **Mandatory when `--print-mode xlsx` is used.**
 
 `--no-color`  
-: Disable colorized output (default: color enabled for terminal, disabled for file output).
+: Disable colorized output (default: color enabled).
 
 `-h`, `--help`  
 : Show this help message and exit.

--- a/docs/apps/cli/iodattributes.md
+++ b/docs/apps/cli/iodattributes.md
@@ -81,5 +81,5 @@ To save the specification model as a CSV file:
 To save the specification model as an Excel (OOXML) file:
 
 ```bash
-    poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1 --print-mode xlsx --output [iod.xlsx](VALID_FILE)
+    poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1 --print-mode xlsx --output iod.xlsx
 ```

--- a/docs/apps/cli/iodattributes.md
+++ b/docs/apps/cli/iodattributes.md
@@ -28,7 +28,15 @@ For more information on configuration and caching location see the [Configuratio
 : Path to the configuration file.
 
 `--print-mode <mode>`  
-: Print as `'table'` (default), `'tree'`, or `'none'` to skip printing.
+: Print as `'table'` (default), `'tree'`, `'csv'`, `'xlsx'`, or `'none'` to skip printing.
+
+- **xlsx**: Writes an OOXML Excel file. Requires `--output` to specify the filename.
+
+`--output <file>`  
+: Path to output file. If not specified, prints to stdout (console).
+
+- When writing to a file, colorization is automatically disabled and plain text is used.
+- **Mandatory when `--print-mode xlsx` is used.**
 
 `-h`, `--help`  
 : Show this help message and exit.
@@ -39,8 +47,36 @@ For more information on configuration and caching location see the [Configuratio
 
 To parse a Composite IOD table and print it as a table:
 
+```bash
     poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1
+```
 
 To parse a Normalized IOD table and print it as a tree:
 
+```bash
     poetry run python -m src.dcmspec.apps.cli.iodattributes table_B.1-1 --print-mode tree
+```
+
+To parse a Normalized IOD table and print it as a tree:
+
+```bash
+    poetry run python -m src.dcmspec.apps.cli.iodattributes table_B.1-1 --print-mode tree
+```
+
+To save the specification model as an ASCII table to a text file:
+
+```bash
+    poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1 --output iod.txt
+```
+
+To save the specification model as a CSV file:
+
+```bash
+    poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1 --print-mode csv --output iod.csv
+```
+
+To save the specification model as an Excel (OOXML) file:
+
+```bash
+    poetry run python -m src.dcmspec.apps.cli.iodattributes table_A.1-1 --print-mode xlsx --output [iod.xlsx](VALID_FILE)
+```

--- a/docs/apps/cli/iodattributes.md
+++ b/docs/apps/cli/iodattributes.md
@@ -38,6 +38,9 @@ For more information on configuration and caching location see the [Configuratio
 - When writing to a file, colorization is automatically disabled and plain text is used.
 - **Mandatory when `--print-mode xlsx` is used.**
 
+`--no-color`  
+: Disable colorized output (default: color enabled for terminal, disabled for file output).
+
 `-h`, `--help`  
 : Show this help message and exit.
 

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -38,7 +38,7 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 : Force update of the specifications merged from part 6, even if cached. Only applies when `--add-part6` is used.
 
 `--print-mode <mode>`  
-: Print as `'table'` (default), `'tree'`,, `'csv'`, or `'none'` to skip printing.
+: Print as `'table'` (default), `'tree'`, `'csv'`, or `'none'` to skip printing.
 
 `--include-depth <int>`  
 : Depth to which included tables should be parsed (default: unlimited, 0: none).

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -6,7 +6,7 @@ CLI for extracting, caching, and printing DICOM Module Attributes tables from Pa
 
 This CLI downloads, caches, and prints the attributes of a given DICOM Module from Part 3 of the DICOM standard. Optionally, it can enrich the module with VR, VM, Keyword, or Status information from Part 6 (Data Elements dictionary).
 
-The tool parses the specified Module Attributes table to extract all attributes, tags, types, and descriptions for the module. Optionally, it can merge in VR, VM, Keyword, or Status information from Part 6. The output can be printed as a table, tree or csv either to the console or to a specified file.
+The tool parses the specified Module Attributes table to extract all attributes, tags, types, and descriptions for the module. Optionally, it can merge in VR, VM, Keyword, or Status information from Part 6. The output can be printed as a table, tree, CSV, or Excel (OOXML) either to the console or to a specified file.
 
 The resulting model is cached as a JSON file. The primary purpose of this cache file is to provide a structured, machine-readable representation of the module's attributes, which can be used for further processing or integration in other tools. As a secondary benefit, the cache file is also used to speed up subsequent runs of the CLI scripts.
 
@@ -26,6 +26,8 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 `[options]`  
 : Additional command-line options (see below).
 
+---
+
 ## Options
 
 `--config <file>`  
@@ -38,10 +40,15 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 : Force update of the specifications merged from part 6, even if cached. Only applies when `--add-part6` is used.
 
 `--print-mode <mode>`  
-: Print as `'table'` (default), `'tree'`, `'csv'`, or `'none'` to skip printing.
+: Print as `'table'` (default), `'tree'`, `'csv'`, `'xlsx'`, or `'none'` to skip printing.
+
+- **xlsx**: Writes an OOXML Excel file. Requires `--output` to specify the filename.
 
 `--output <file>`  
-: Path to output file. If not specified, prints to stdout (console). When writing to a file, colorization is automatically disabled and plain text is used.
+: Path to output file. If not specified, prints to stdout (console).
+
+- When writing to a file, colorization is automatically disabled and plain text is used.
+- **Mandatory when `--print-mode xlsx` is used.**
 
 `--include-depth <int>`  
 : Depth to which included tables should be parsed (default: unlimited, 0: none).
@@ -77,20 +84,26 @@ To enrich the table with VR and VM information from Part 6:
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --add-part6 VR VM
 ```
 
-To print the result as a tree:
+To print the specification model as a tree:
 
 ```bash
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode tree
 ```
 
-To save the output to a file:
+To save the specification model as a ASCII table to a text file:
 
 ```bash
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --output patient_module.txt
 ```
 
-To save as CSV to a file:
+To save the specification model as a CSV file:
 
 ```bash
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode csv --output patient_module.csv
+```
+
+To save the specification model as an Excel (OOXML) file:
+
+```bash
+poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode xlsx --output patient_module.xlsx
 ```

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -6,7 +6,7 @@ CLI for extracting, caching, and printing DICOM Module Attributes tables from Pa
 
 This CLI downloads, caches, and prints the attributes of a given DICOM Module from Part 3 of the DICOM standard. Optionally, it can enrich the module with VR, VM, Keyword, or Status information from Part 6 (Data Elements dictionary).
 
-The tool parses the specified Module Attributes table to extract all attributes, tags, types, and descriptions for the module. Optionally, it can merge in VR, VM, Keyword, or Status information from Part 6. The output can be printed as a table or tree.
+The tool parses the specified Module Attributes table to extract all attributes, tags, types, and descriptions for the module. Optionally, it can merge in VR, VM, Keyword, or Status information from Part 6. The output can be printed as a table, tree or csv either to the console or to a specified file.
 
 The resulting model is cached as a JSON file. The primary purpose of this cache file is to provide a structured, machine-readable representation of the module's attributes, which can be used for further processing or integration in other tools. As a secondary benefit, the cache file is also used to speed up subsequent runs of the CLI scripts.
 
@@ -39,6 +39,9 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 
 `--print-mode <mode>`  
 : Print as `'table'` (default), `'tree'`, `'csv'`, or `'none'` to skip printing.
+
+`--output <file>`  
+: Path to output file. If not specified, prints to stdout (console). When writing to a file, colorization is automatically disabled and plain text is used.
 
 `--include-depth <int>`  
 : Depth to which included tables should be parsed (default: unlimited, 0: none).
@@ -78,4 +81,16 @@ To print the result as a tree:
 
 ```bash
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode tree
+```
+
+To save the output to a file:
+
+```bash
+poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --output patient_module.txt
+```
+
+To save as CSV to a file:
+
+```bash
+poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode csv --output patient_module.csv
 ```

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -50,6 +50,9 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 - When writing to a file, colorization is automatically disabled and plain text is used.
 - **Mandatory when `--print-mode xlsx` is used.**
 
+`--no-color`  
+: Disable colorized output (default: color enabled for terminal, disabled for file output).
+
 `--include-depth <int>`  
 : Depth to which included tables should be parsed (default: unlimited, 0: none).
 

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -51,7 +51,7 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 - **Mandatory when `--print-mode xlsx` is used.**
 
 `--no-color`  
-: Disable colorized output (default: color enabled for terminal, disabled for file output).
+: Disable colorized output (default: color enabled).
 
 `--include-depth <int>`  
 : Depth to which included tables should be parsed (default: unlimited, 0: none).

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -38,10 +38,10 @@ poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
 : Force update of the specifications merged from part 6, even if cached. Only applies when `--add-part6` is used.
 
 `--print-mode <mode>`  
-: Print as `'table'` (default), `'tree'`, or `'none'` to skip printing.
+: Print as `'table'` (default), `'tree'`,, `'csv'`, or `'none'` to skip printing.
 
 `--include-depth <int>`  
-: Depth to which included tables should be parsed (default: unlimited).
+: Depth to which included tables should be parsed (default: unlimited, 0: none).
 
 `--force-parse`  
 : Force reparsing of the DOM and regeneration of the JSON model, even if the JSON cache exists.

--- a/docs/apps/cli/modattributes.md
+++ b/docs/apps/cli/modattributes.md
@@ -90,7 +90,7 @@ To print the specification model as a tree:
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode tree
 ```
 
-To save the specification model as a ASCII table to a text file:
+To save the specification model as an ASCII table to a text file:
 
 ```bash
 poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --output patient_module.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dcmspec"
-version = "0.2.3"
+version = "0.3.0"
 description = "Toolkit for extracting, parsing, and processing DICOM specifications."
 authors = [{ name = "David Wikler", email = "david.wikler@ulb.be" }]
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "requests (>=2.32.3,<3.0.0)",
     "lxml (>=5.4.0,<6.0.0)",
     "rich (>=14.0.0,<15.0.0)",
+    "html2text (>=2025.4.15,<2026.0.0)",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "lxml (>=5.4.0,<6.0.0)",
     "rich (>=14.0.0,<15.0.0)",
     "html2text (>=2025.4.15,<2026.0.0)",
+    "openpyxl (>=3.1.5,<4.0.0)",
 ]
 
 [project.urls]

--- a/src/dcmspec/apps/cli/iodattributes.py
+++ b/src/dcmspec/apps/cli/iodattributes.py
@@ -63,6 +63,11 @@ def main():
         help="Print as 'table' (default), 'tree', 'csv', 'xlsx' (requires --output), or 'none' to skip printing"
     )
     parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colorized output (default: color enabled for terminal, disabled for file output)"
+    )
+    parser.add_argument(
         "--output",
         type=str,
         help="Path to output file. If not specified (and not xlsx), prints to stdout."
@@ -123,14 +128,18 @@ def main():
 
     # Print the model
     printer = IODSpecPrinter(model, output=getattr(args, "output", None))
+
+    # Determine use_color: disable if --no-color, or if outputting to file and --no-color not set
+    use_color = False if args.no_color else args.output is None
+
     if args.print_mode == "tree":
-        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=True)
+        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color)
     elif args.print_mode == "table":
-        printer.print_table(colorize=True, column_widths=[30, 11, 4, 60])
+        printer.print_table(colorize=use_color, column_widths=[30, 11, 4, 60])
     elif args.print_mode == "csv":
-        printer.print_csv(colorize=True)
+        printer.print_csv(colorize=use_color)
     elif args.print_mode == "xlsx":
-        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=True)
+        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=use_color)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/iodattributes.py
+++ b/src/dcmspec/apps/cli/iodattributes.py
@@ -58,11 +58,19 @@ def main():
     parser.add_argument("--config", help="Path to the configuration file")
     parser.add_argument(
         "--print-mode", 
-        choices=["table", "tree", "none"],
+        choices=["table", "tree", "csv", "xlsx", "none"],
         default="table",
-        help="Print as 'table' (default), 'tree', or 'none' to skip printing"
+        help="Print as 'table' (default), 'tree', 'csv', 'xlsx' (requires --output), or 'none' to skip printing"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Path to output file. If not specified (and not xlsx), prints to stdout."
     )
     args = parser.parse_args()
+
+    if args.print_mode == "xlsx" and not args.output:
+        parser.error("--output is required when --print-mode xlsx")
 
     cache_file_name = "Part3.xhtml"
     model_file_name = f"Part3_{args.table}_expanded.json"
@@ -114,11 +122,15 @@ def main():
     )
 
     # Print the model
-    printer = IODSpecPrinter(model)
+    printer = IODSpecPrinter(model, output=getattr(args, "output", None))
     if args.print_mode == "tree":
-        printer.print_tree(colorize=True)
+        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=True)
     elif args.print_mode == "table":
-        printer.print_table(colorize=True)
+        printer.print_table(colorize=True, column_widths=[30, 11, 4, 60])
+    elif args.print_mode == "csv":
+        printer.print_csv(colorize=True)
+    elif args.print_mode == "xlsx":
+        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=True)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/iodattributes.py
+++ b/src/dcmspec/apps/cli/iodattributes.py
@@ -129,8 +129,8 @@ def main():
     # Print the model
     printer = IODSpecPrinter(model, output=getattr(args, "output", None))
 
-    # Determine use_color: disable if --no-color, or if outputting to file and --no-color not set
-    use_color = False if args.no_color else args.output is None
+    # Only disable color if --no-color is set; SpecPrinter disables color for file outputs automatically
+    use_color = not args.no_color
 
     if args.print_mode == "tree":
         printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color)

--- a/src/dcmspec/apps/cli/iodattributes.py
+++ b/src/dcmspec/apps/cli/iodattributes.py
@@ -133,7 +133,9 @@ def main():
     use_color = not args.no_color
 
     if args.print_mode == "tree":
-        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color)
+        printer.print_tree(
+            attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color
+            )
     elif args.print_mode == "table":
         printer.print_table(colorize=use_color, column_widths=[30, 11, 4, 60])
     elif args.print_mode == "csv":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -166,7 +166,7 @@ def main():
         "--print-mode", 
         choices=["table", "tree", "csv", "none"],
         default="table",
-        help="Print as 'table' (default), 'tree', or 'none' to skip printing"
+        help="Print as 'table' (default), 'tree', 'csv', or 'none' to skip printing"
     )
     parser.add_argument(
         "--add-part6",

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -172,6 +172,11 @@ def main():
         help="Print as 'table' (default), 'tree', 'csv', 'xlsx' (requires --output), or 'none' to skip printing"
     )
     parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colorized output (default: color enabled for terminal, disabled for file output)"
+    )
+    parser.add_argument(
         "--output",
         type=str,
         help="Path to output file. If not specified (and not xlsx), prints to stdout."
@@ -197,7 +202,7 @@ def main():
         action="store_true",
         help="Enable verbose (info-level) logging to the console"
     )
-    
+
     args = parser.parse_args()
 
     if args.print_mode == "xlsx" and not args.output:
@@ -266,14 +271,17 @@ def main():
 
     logger.debug("Model ready for printing/output")
     printer = SpecPrinter(model, output=args.output)
+
+    # Determine use_color: disable if --no-color, or if outputting to file and --no-color not set
+    use_color = False if args.no_color else args.output is None
     if args.print_mode == "tree":
-        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=True)
+        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color)
     elif args.print_mode == "table":
-        printer.print_table(colorize=True, column_widths=[30, 11, 4, 60])
+        printer.print_table(colorize=use_color, column_widths=[30, 11, 4, 60])
     elif args.print_mode == "csv":
-        printer.print_csv(colorize=True)
+        printer.print_csv(colorize=use_color)
     elif args.print_mode == "xlsx":
-        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=True)
+        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=use_color)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -273,7 +273,7 @@ def main():
     elif args.print_mode == "csv":
         printer.print_csv(colorize=True)
     elif args.print_mode == "xlsx":
-        printer.print_xlsx(output=args.output, column_widths=[60, 16, 10, 100], colorize=True)
+        printer.print_xlsx(column_widths=[60, 16, 10, 100], colorize=True)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -116,9 +116,9 @@ def main():
     from Part 6. The output can be printed as a table or tree.
 
     The resulting model is cached as a JSON file. The primary purpose of this cache file is to provide
-    a structured, machine-readable representation of the module's attributes, which can be used for further processing
-    or integration in other tools. As a secondary benefit, the cache file is also used to speed up subsequent runs
-    of the CLI scripts.
+    a structured, machine-readable representation of the module's attributes, which can be used for
+    further processing or integration in other tools. As a secondary benefit, the cache file is also used
+    to speed up subsequent runs of the CLI scripts.
 
     Usage:
         poetry run python -m src.dcmspec.apps.cli.modattributes <table_id> [options]
@@ -129,7 +129,7 @@ def main():
         --include-depth (int): Depth to which included tables should be parsed (default: unlimited).
         --force-parse: Force reparsing of the DOM and regeneration of the JSON model.
         --force-download: Force download of the input file and regeneration of the model.
-        --print-mode (str): Print as 'table' (default), 'tree', or 'none' to skip printing.
+        --print-mode (str): Print as 'table' (default), 'tree','csv', or 'none' to skip printing.
         --output (str): Path to output file. If not specified, prints to stdout.
         --add-part6 (list): Specification(s) to merge from Part 6 (e.g., --add-part6 VR VM).
         --force-update: Force update of the specifications merged from part 6, even if cached.

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -4,7 +4,7 @@ Features:
 - Download and parse DICOM Module Attributes tables from Part 3 of the DICOM standard.
 - Optionally merge additional information (VR, VM, Keyword, Status) from Part 6.
 - Cache the resulting model as a JSON file for future runs and as a structured representation of the standard.
-- Print the resulting model as a table or tree.
+- Print the resulting model as a table, tree, csv, or xlsx.
 - Supports caching, configuration files, and command-line options for flexible workflows.
 
 Usage:
@@ -113,7 +113,7 @@ def main():
 
     The tool parses the specified Module Attributes table to extract all attributes, tags, types,
     and descriptions for the module. Optionally, it can merge in VR, VM, Keyword, or Status information
-    from Part 6. The output can be printed as a table or tree.
+    from Part 6. The output can be printed as a table, tree, csv, or xlsx (xlsx requires --output).
 
     The resulting model is cached as a JSON file. The primary purpose of this cache file is to provide
     a structured, machine-readable representation of the module's attributes, which can be used for
@@ -129,15 +129,17 @@ def main():
         --include-depth (int): Depth to which included tables should be parsed (default: unlimited).
         --force-parse: Force reparsing of the DOM and regeneration of the JSON model.
         --force-download: Force download of the input file and regeneration of the model.
-        --print-mode (str): Print as 'table' (default), 'tree','csv', or 'none' to skip printing.
-        --output (str): Path to output file. If not specified, prints to stdout.
+        --print-mode (str): Print as 'table' (default), 'tree', 'csv', 'xlsx', or 'none' to skip printing.
+                            'xlsx' requires --output.
+        --output (str): Path to output file. If not specified (and not xlsx), prints to stdout.
         --add-part6 (list): Specification(s) to merge from Part 6 (e.g., --add-part6 VR VM).
         --force-update: Force update of the specifications merged from part 6, even if cached.
         -d, --debug: Enable debug logging to the console.
         -v, --verbose: Enable verbose (info-level) logging to the console.
 
-    Example:
+    Examples:
         poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --add-part6 VR VM
+        poetry run python -m src.dcmspec.apps.cli.modattributes table_C.7-1 --print-mode xlsx --output module.xlsx
 
     """
     # Parse command-line arguments
@@ -165,14 +167,14 @@ def main():
     )
     parser.add_argument(
         "--print-mode", 
-        choices=["table", "tree", "csv", "none"],
+        choices=["table", "tree", "csv", "xlsx", "none"],
         default="table",
-        help="Print as 'table' (default), 'tree', 'csv', or 'none' to skip printing"
+        help="Print as 'table' (default), 'tree', 'csv', 'xlsx' (requires --output), or 'none' to skip printing"
     )
     parser.add_argument(
         "--output",
         type=str,
-        help="Path to output file. If not specified, prints to stdout."
+        help="Path to output file. If not specified (and not xlsx), prints to stdout."
     )
     parser.add_argument(
         "--add-part6",
@@ -197,6 +199,9 @@ def main():
     )
     
     args = parser.parse_args()
+
+    if args.print_mode == "xlsx" and not args.output:
+        parser.error("--output is required when --print-mode xlsx")
 
     # Set up logger
     logger = logging.getLogger("modattributes")
@@ -267,6 +272,8 @@ def main():
         printer.print_table(colorize=True, column_widths=[30, 11, 4, 60])
     elif args.print_mode == "csv":
         printer.print_csv(colorize=True)
+    elif args.print_mode == "xlsx":
+        printer.print_xlsx(output=args.output, column_widths=[60, 16, 10, 100], colorize=True)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -130,6 +130,7 @@ def main():
         --force-parse: Force reparsing of the DOM and regeneration of the JSON model.
         --force-download: Force download of the input file and regeneration of the model.
         --print-mode (str): Print as 'table' (default), 'tree', or 'none' to skip printing.
+        --output (str): Path to output file. If not specified, prints to stdout.
         --add-part6 (list): Specification(s) to merge from Part 6 (e.g., --add-part6 VR VM).
         --force-update: Force update of the specifications merged from part 6, even if cached.
         -d, --debug: Enable debug logging to the console.
@@ -167,6 +168,11 @@ def main():
         choices=["table", "tree", "csv", "none"],
         default="table",
         help="Print as 'table' (default), 'tree', 'csv', or 'none' to skip printing"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Path to output file. If not specified, prints to stdout."
     )
     parser.add_argument(
         "--add-part6",
@@ -254,9 +260,9 @@ def main():
         model = module_model
 
     logger.debug("Model ready for printing/output")
-    printer = SpecPrinter(model)
+    printer = SpecPrinter(model, output=args.output)
     if args.print_mode == "tree":
-        printer.print_tree(colorize=True)
+        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64], colorize=True)
     elif args.print_mode == "table":
         printer.print_table(colorize=True)
     elif args.print_mode == "csv":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -164,7 +164,7 @@ def main():
     )
     parser.add_argument(
         "--print-mode", 
-        choices=["table", "tree", "none"],
+        choices=["table", "tree", "csv", "none"],
         default="table",
         help="Print as 'table' (default), 'tree', or 'none' to skip printing"
     )
@@ -259,6 +259,8 @@ def main():
         printer.print_tree(colorize=True)
     elif args.print_mode == "table":
         printer.print_table(colorize=True)
+    elif args.print_mode == "csv":
+        printer.print_csv(colorize=True)
     # else: do not print anything if print_mode == "none"
 
 if __name__ == "__main__":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -272,8 +272,8 @@ def main():
     logger.debug("Model ready for printing/output")
     printer = SpecPrinter(model, output=args.output)
 
-    # Determine use_color: disable if --no-color, or if outputting to file and --no-color not set
-    use_color = False if args.no_color else args.output is None
+    # Only disable color if --no-color is set; SpecPrinter disables color for file outputs automatically
+    use_color = not args.no_color
     if args.print_mode == "tree":
         printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=use_color)
     elif args.print_mode == "table":

--- a/src/dcmspec/apps/cli/modattributes.py
+++ b/src/dcmspec/apps/cli/modattributes.py
@@ -262,9 +262,9 @@ def main():
     logger.debug("Model ready for printing/output")
     printer = SpecPrinter(model, output=args.output)
     if args.print_mode == "tree":
-        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64], colorize=True)
+        printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 100], colorize=True)
     elif args.print_mode == "table":
-        printer.print_table(colorize=True)
+        printer.print_table(colorize=True, column_widths=[30, 11, 4, 60])
     elif args.print_mode == "csv":
         printer.print_csv(colorize=True)
     # else: do not print anything if print_mode == "none"

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -807,25 +807,35 @@ class DOMTableSpecParser(SpecParser):
 
         return cleaned.strip()
 
-    def _sanitize_string(self, input_string: str) -> str:
-        """Sanitize string to use it as a node attribute name.
+    @staticmethod
+    def _sanitize_string(input_string: str) -> str:
+        """
+        Sanitize a string to make it safe for use as a node attribute name.
 
-        - Convert non-ASCII characters to closest ASCII equivalents
-        - Replace space characters and slashes with underscores
-        - Replace parentheses characters with dashes
+        Transformations applied:
+        - Convert to lowercase.
+        - Transliterate non-ASCII characters to ASCII.
+        - Replace spaces, slashes, newlines, and dots with underscores ("_").
+        - Replace parentheses with dashes ("-").
+        - Remove all characters except letters, digits, underscores, and dashes.
+        - Collapse multiple consecutive underscores into a single underscore.
+        - Remove leading and trailing underscores for cleanliness.
 
         Args:
-            input_string (str): The string to be sanitized.
+            input_string (str): The original string to sanitize.
 
         Returns:
-            str: The sanitized string.
+            str: A sanitized version of the input string, suitable for use as an identifier.
 
+        Example:
+            >>> DOMTableSpecParser._sanitize_string('>>Include\\nTable C.36.2.2.19-1 "RT Beam Limiting Device Definition Macro Attributes"\\n.')
+            'include_table_c_36_2_2_19-1_rt_beam_limiting_device_definition_macro_attributes'
         """
-        # Normalize the string to NFC form and transliterate to ASCII
         normalized_str = unidecode(input_string.lower())
-        # Replace spaces and slashes with underscores, parentheses with dashes, and single quotes with underscores
-        return re.sub(
-            r"[ /\-()']",
-            lambda match: "-" if match.group(0) in "()" else "_",
-            normalized_str,
-        )
+        sanitized = re.sub(r"[ /\n\\.]", "_", normalized_str)  # spaces, slashes, newlines, dots → _
+        sanitized = re.sub(r"[()]", "-", sanitized)            # parentheses → -
+        sanitized = re.sub(r"[^a-z0-9_\\-]", "", sanitized)    # remove other chars
+        sanitized = re.sub(r"_+", "_", sanitized)              # collapse multiple underscores
+        sanitized = sanitized.strip("_")                       # remove leading/trailing underscores
+        return sanitized
+    

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -509,6 +509,7 @@ class DOMTableSpecParser(SpecParser):
 
         return logical_cells, logical_col_idx, physical_col_idx
 
+
     def _extract_cell_value(
         self,
         cell: Tag,
@@ -516,25 +517,32 @@ class DOMTableSpecParser(SpecParser):
         unformatted_list: list[bool]
     ) -> str:
         """Extract and clean the value from a cell as unformatted text or HTML."""
+        
         use_unformatted = (
             unformatted_list[logical_col_idx]
             if unformatted_list and logical_col_idx < len(unformatted_list)
             else True
         )
 
-        if use_unformatted:
-            # Use html2text for better readability
-            converter = html2text.HTML2Text()
-            converter.ignore_links = True       # Remove URLs
-            converter.ignore_images = True      # Remove image references
-            converter.ignore_emphasis = True    # Remove Markdown emphasis
-            converter.body_width = 0            # Disable word wrapping
-
-            raw_text = converter.handle(str(cell))
-            return self._clean_extracted_text(raw_text)
-        else:
+        # Guard clause: if formatted HTML is required, return content as-is
+        if not use_unformatted:
             # Keep original HTML content
             return self._clean_extracted_text(cell.decode_contents())
+
+        # Use html2text for better readability of unformatted text extraction
+        converter = self._create_html2text_converter()
+        raw_text = converter.handle(str(cell))
+        return self._clean_extracted_text(raw_text)
+
+
+    def _create_html2text_converter(self) -> html2text.HTML2Text:
+        """Create and configure an html2text converter for consistent text extraction."""
+        converter = html2text.HTML2Text()
+        converter.ignore_links = True       # Remove URLs
+        converter.ignore_images = True      # Remove image references
+        converter.ignore_emphasis = True    # Remove Markdown emphasis
+        converter.body_width = 0            # Disable word wrapping
+        return converter
 
     def _update_rowspan_trackers(
         self,

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -820,22 +820,31 @@ class DOMTableSpecParser(SpecParser):
         - Remove all characters except letters, digits, underscores, and dashes.
         - Collapse multiple consecutive underscores into a single underscore.
         - Remove leading and trailing underscores for cleanliness.
+        - Return a default name if the result is empty after sanitization.
 
         Args:
             input_string (str): The original string to sanitize.
 
         Returns:
             str: A sanitized version of the input string, suitable for use as an identifier.
+                 Returns "unnamed_node" if sanitization results in an empty string.
 
         Example:
             >>> DOMTableSpecParser._sanitize_string('>>Include\\nTable C.36.2.2.19-1 "RT Beam Limiting Device Definition Macro Attributes"\\n.')
             'include_table_c_36_2_2_19-1_rt_beam_limiting_device_definition_macro_attributes'
+            >>> DOMTableSpecParser._sanitize_string('...')
+            'unnamed_node'
         """
         normalized_str = unidecode(input_string.lower())
         sanitized = re.sub(r"[ /\n\\.]", "_", normalized_str)  # spaces, slashes, newlines, dots → _
         sanitized = re.sub(r"[()]", "-", sanitized)            # parentheses → -
-        sanitized = re.sub(r"[^a-z0-9_\\-]", "", sanitized)    # remove other chars
+        sanitized = re.sub(r"[^a-z0-9_-]", "", sanitized)      # remove other chars
         sanitized = re.sub(r"_+", "_", sanitized)              # collapse multiple underscores
         sanitized = sanitized.strip("_")                       # remove leading/trailing underscores
+        
+        # Fallback to default name if sanitization resulted in empty string
+        if not sanitized:
+            return "unnamed_node"
+        
         return sanitized
-    
+

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -517,7 +517,6 @@ class DOMTableSpecParser(SpecParser):
         unformatted_list: list[bool]
     ) -> str:
         """Extract and clean the value from a cell as unformatted text or HTML."""
-        
         use_unformatted = (
             unformatted_list[logical_col_idx]
             if unformatted_list and logical_col_idx < len(unformatted_list)
@@ -825,8 +824,7 @@ class DOMTableSpecParser(SpecParser):
 
     @staticmethod
     def _sanitize_string(input_string: str) -> str:
-        """
-        Sanitize a string to make it safe for use as a node attribute name.
+        r"""Sanitize a string to make it safe for use as a node attribute name.
 
         Transformations applied:
         - Convert to lowercase.
@@ -843,13 +841,16 @@ class DOMTableSpecParser(SpecParser):
 
         Returns:
             str: A sanitized version of the input string, suitable for use as an identifier.
-                 Returns "unnamed_node" if sanitization results in an empty string.
+                    or "unnamed_node" if sanitization results in an empty string.
 
         Example:
-            >>> DOMTableSpecParser._sanitize_string('>>Include\\nTable C.36.2.2.19-1 "RT Beam Limiting Device Definition Macro Attributes"\\n.')
+            >>> DOMTableSpecParser._sanitize_string(
+            '>>Include\\nTable C.36.2.2.19-1 "RT Beam Limiting Device Definition Macro Attributes"\\n.'
+            )
             'include_table_c_36_2_2_19-1_rt_beam_limiting_device_definition_macro_attributes'
             >>> DOMTableSpecParser._sanitize_string('...')
             'unnamed_node'
+
         """
         normalized_str = unidecode(input_string.lower())
         sanitized = re.sub(r"[ /\n\\.]", "_", normalized_str)  # spaces, slashes, newlines, dots → _
@@ -857,10 +858,7 @@ class DOMTableSpecParser(SpecParser):
         sanitized = re.sub(r"[^a-z0-9_-]", "", sanitized)      # remove other chars
         sanitized = re.sub(r"_+", "_", sanitized)              # collapse multiple underscores
         sanitized = sanitized.strip("_")                       # remove leading/trailing underscores
-        
+
         # Fallback to default name if sanitization resulted in empty string
-        if not sanitized:
-            return "unnamed_node"
-        
-        return sanitized
+        return sanitized or "unnamed_node"
 

--- a/src/dcmspec/dom_table_spec_parser.py
+++ b/src/dcmspec/dom_table_spec_parser.py
@@ -3,15 +3,18 @@
 Provides the DOMSpecParser class for parsing DICOM specification tables from XHTML documents,
 converting them into structured in-memory representations using anytree.
 """
+
 from contextlib import contextmanager
 import re
 import unicodedata
+from typing import Any, Dict, Optional, Union
+
 from unidecode import unidecode
 from anytree import Node
 from bs4 import BeautifulSoup, Tag
-from typing import Any, Dict, Optional, Union
-from dcmspec.spec_parser import SpecParser
+import html2text
 
+from dcmspec.spec_parser import SpecParser
 from dcmspec.dom_utils import DOMUtils
 from dcmspec.progress import Progress, ProgressObserver, ProgressStatus, calculate_percent
 
@@ -518,9 +521,19 @@ class DOMTableSpecParser(SpecParser):
             if unformatted_list and logical_col_idx < len(unformatted_list)
             else True
         )
+
         if use_unformatted:
-            return self._clean_extracted_text(cell.get_text(separator="\n", strip=True))
+            # Use html2text for better readability
+            converter = html2text.HTML2Text()
+            converter.ignore_links = True       # Remove URLs
+            converter.ignore_images = True      # Remove image references
+            converter.ignore_emphasis = True    # Remove Markdown emphasis
+            converter.body_width = 0            # Disable word wrapping
+
+            raw_text = converter.handle(str(cell))
+            return self._clean_extracted_text(raw_text)
         else:
+            # Keep original HTML content
             return self._clean_extracted_text(cell.decode_contents())
 
     def _update_rowspan_trackers(
@@ -781,15 +794,7 @@ class DOMTableSpecParser(SpecParser):
         return header
 
     def _clean_extracted_text(self, text: str) -> str:
-        """Clean extracted text using Unicode normalization and regex.
-
-        Args:
-            text (str): The text to be cleaned.
-
-        Returns:
-            str: The cleaned text.
-
-        """
+        """Clean extracted text using Unicode normalization and regex."""
         # Normalize unicode characters to compatibility form
         cleaned = unicodedata.normalize('NFKC', text)
 
@@ -804,6 +809,9 @@ class DOMTableSpecParser(SpecParser):
         cleaned = re.sub(r'[\u2013\u2014]', '-', cleaned)
         # Remove stray Â character
         cleaned = cleaned.replace('\u00c2', '')
+
+        # Collapse multiple newlines (including those separated by spaces/tabs) into a single newline
+        cleaned = re.sub(r'(\n\s*){2,}', '\n', cleaned)
 
         return cleaned.strip()
 

--- a/src/dcmspec/iod_spec_printer.py
+++ b/src/dcmspec/iod_spec_printer.py
@@ -3,10 +3,15 @@
 Provides the SpecPrinter class for printing DICOM IOD specification models (SpecModel)
 to standard output, either as a hierarchical tree or as a flat table, using rich formatting.
 """
-from anytree import PreOrderIter
-from rich.table import Table, box
+import re
+from typing import Generator, List, Optional, Tuple
 
-from dcmspec.spec_printer import LEVEL_COLORS, SpecPrinter
+from anytree import PreOrderIter
+from anytree import RenderTree
+from rich.table import Table, box
+from rich.text import Text
+
+from dcmspec.spec_printer import LEVEL_COLORS, SPECIAL_COLORS, SpecPrinter
 
 class IODSpecPrinter(SpecPrinter):
     """Printer for DICOM IOD specification models with mixed node types.
@@ -15,45 +20,233 @@ class IODSpecPrinter(SpecPrinter):
     The table columns are those of the Module Attributes nodes.
     """
 
-    def print_table(self, colorize: bool = False):
-        """Print the specification model as a flat table with module title rows.
+    def print_tree(
+        self,
+        attr_names=None,
+        attr_widths=None,
+        colorize: bool = False,
+    ) -> None:
+        """Print the specification model as a hierarchical tree to the console or file.
 
         Args:
-            colorize (bool): Whether to colorize the output by node depth.
+            attr_names (Optional[Union[str, list[str]]]): Attribute name(s) to display for each node.
+            attr_widths (Optional[list[int]]): List of widths for each attribute in attr_names.
+            colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
+
+        Returns:
+            None
 
         """
-        table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
+        if self.output:
+            colorize = False
 
-        attr_headers = list(self.model.metadata.header)
-        for header in attr_headers:
-            table.add_column(header, width=20)
-
-        # Traverse the tree in PreOrder (as in the base class)
-        for node in PreOrderIter(self.model.content):
-            # skip the root node
+        for pre, fill, node in RenderTree(self.model.content):
             if node.name == "content":
-                continue            # Print IOD module nodes as a title row (one cell, spanning all columns)
+                continue
+
             if hasattr(node, "module"):
+                # Module title row: always use title color if colorize
                 iod_title = getattr(node, "module", getattr(node, "name", ""))
                 iod_usage = getattr(node, "usage", "")
                 iod_title_text = f"{iod_title} Module ({iod_usage})" if iod_usage else iod_title
-                # Set title style
-                row_style = (
-                    "magenta" if colorize else None
-                )
-                table.add_row(iod_title_text, *[""] * (len(attr_headers) - 1), style=row_style)
-            # Print module attribute nodes as regular rows
+                node_text = Text(iod_title_text, style=SPECIAL_COLORS["title"] if colorize else None)
             else:
+                attr_text = self._format_tree_row(node, attr_names, attr_widths)
+                row_style = self._get_tree_row_style(node, colorize)
+                node_text = Text(attr_text, style=row_style)
+            self.console.print(Text(pre) + node_text)
+
+        if self.console.file:
+            self.console.file.flush()
+
+    def print_table(self, column_widths=None, colorize: bool = False) -> None:
+        """Print the specification model as a flat table with module title rows.
+
+        Args:
+            column_widths (Optional[List[int]]): List of widths for each column's content.
+                These widths do not include borders or padding added by Rich.
+                If provided, each column will be set to the specified content width.
+                If None, all columns default to width 20.            
+                If the list is shorter than the number of columns, remaining columns default to width 20.
+
+            colorize (bool): Whether to colorize the output by node depth.
+
+        """
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
+
+        table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
+
+        attr_headers = list(self.model.metadata.header)
+        for i, header in enumerate(attr_headers):
+            width = column_widths[i] if column_widths and i < len(column_widths) else 20
+            table.add_column(header, width=width)
+
+        for row, row_style, _ in self._iterate_rows_iod(colorize):
+            table.add_row(*row, style=row_style)
+
+        self.console.print(table)
+
+        if self.console.file:
+            self.console.file.flush()  # Ensure data is written immediately
+
+    def print_csv(self, colorize: bool = False) -> None:
+        """Print the specification model as CSV to the console or file, with module title rows.
+
+        Traverses the content tree and prints each node's attributes in CSV format,
+        with column headers from the metadata node. Optionally colorizes rows.
+
+        Args:
+            colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
+
+        Returns:
+            None
+
+        """
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
+
+        # Print CSV header
+        header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
+        self.console.print(header_row)
+
+        # Add data rows (including module title rows)
+        for row, row_style, _ in self._iterate_rows_iod(colorize):
+            # Escape quotes inside each field by doubling them, then wrap in quotes
+            csv_row = ",".join(
+                f'"{("" if cell is None else str(cell)).replace(chr(34), chr(34) + chr(34))}"'
+                for cell in row
+            )
+            self.console.print(csv_row, style=row_style)
+
+        if self.console.file:
+            self.console.file.flush()
+
+    def print_xlsx(self, column_widths: Optional[list] = None, colorize: bool = False) -> None:
+        """Print the specification model to an OOXML format Excel (.xlsx) file.
+
+        Traverses the content tree and writes each node's attributes into an Excel sheet,
+        with column headers from the metadata node. Handles newlines and applies background
+        colorization using the same color scheme as console output (LEVEL_COLORS and SPECIAL_COLORS).
+        Each module in the IOD is written to a separate worksheet, named after the module, and attribute rows
+        for each module are written to their corresponding worksheet.
+
+        Args:
+            column_widths (list): Optional list of column widths for Excel columns.
+            colorize (bool): Whether to apply color styling to cell backgrounds.
+
+        Returns:
+            None
+
+        """
+        if not self.output:
+            raise ValueError("Output file path must be specified when constructing SpecPrinter for print_xlsx).")
+
+        header_style, data_style = self._create_styles()
+        wb = self._setup_workbook()
+        ws = None
+        current_module = None
+        rows_for_ws = []
+
+        def flush_ws():
+            if ws and rows_for_ws:
+                self._write_data_rows(ws, rows_for_ws, data_style, colorize)
+                rows_for_ws.clear()
+
+        used_names = set()
+        for row, row_style, module_name in self._iterate_rows_iod(colorize=colorize, include_module_titles=False):
+            if module_name != current_module:
+                flush_ws()
+                
+                ws = self._setup_worksheet(wb, self._sanitize_sheet_name(module_name, used_names))
+                self._write_headers(ws, self.model.metadata.header, header_style)
+                if column_widths:
+                    self._set_column_widths(ws, column_widths)
+                current_module = module_name
+            rows_for_ws.append((row, row_style))
+
+        flush_ws()
+        wb.save(self.output)
+        
+    @staticmethod
+    def _sanitize_sheet_name(name: str, used_names: set = None) -> str:
+        """Sanitize and ensure uniqueness of a worksheet name for Excel compatibility.
+
+        This function replaces invalid characters with underscores and trims the name to 31 characters.
+        If the name is empty or None, it uses 'Sheet'. If the name is already used, it appends a numeric
+        suffix to ensure uniqueness within the workbook.
+
+        Args:
+            name (str): The proposed worksheet name.
+            used_names (set, optional): Set of already used worksheet names.
+
+        Returns:
+            str: A sanitized and unique worksheet name suitable for Excel.
+
+        """
+        orig_name = re.sub(r'[\[\]\*:/\\\?]', '_', name) if name else "Sheet"
+        orig_name = orig_name[:31] if orig_name else "Sheet"
+        if used_names is None:
+            used_names = set()
+        sheet_name = orig_name
+        i = 1
+        while sheet_name in used_names or not sheet_name:
+            suffix = f"_{i}"
+            sheet_name = (
+                (orig_name[:31-len(suffix)] + suffix) 
+                if len(orig_name) + len(suffix) > 31 
+                else orig_name + suffix
+            )
+            i += 1
+        used_names.add(sheet_name)
+        return sheet_name
+
+    def _iterate_rows_iod(
+            self, 
+            colorize: bool = False, 
+            include_module_titles: bool = True
+            ) -> Generator[Tuple[List[str], Optional[str], Optional[str]], None, None]:
+        """Generate rows for IODSpecPrinter with module title rows, module grouping, and optional styling.
+
+        Iterates through the model content tree and yields tuples representing each row to be printed.
+        For module nodes, optionnaly yields a module title row with the module name and styling.
+        For attribute rows, yields the attribute values, row style, and the current module name for grouping.
+
+        Args:
+            colorize (bool): Whether to apply color styling to rows.
+            include_module_titles (bool): Whether to yield module title rows (True for table/csv, False for xlsx).
+
+        Yields:
+            tuple: (row_data, row_style, module_name) where row_data is a list of cell values,
+                    row_style is an RGB color string (e.g., "rgb(255,255,0)") from LEVEL_COLORS or SPECIAL_COLORS,
+                    or None if not colorized, and module_name is the current module for grouping.
+
+        """      
+        attr_headers = list(self.model.metadata.header)
+        current_module = None
+        for node in PreOrderIter(self.model.content):
+            if node.name == "content":
+                continue
+            if hasattr(node, "module"):
+                current_module = getattr(node, "module", None)
+                if include_module_titles:
+                    iod_title = getattr(node, "module", getattr(node, "name", ""))
+                    iod_usage = getattr(node, "usage", "")
+                    iod_title_text = f"{iod_title} Module ({iod_usage})" if iod_usage else iod_title
+                    row_style = SPECIAL_COLORS["title"] if colorize else None
+                    yield [iod_title_text] + [""] * (len(attr_headers) - 1), row_style, current_module or "Other"
+                # else: skip module title rows for xlsx
+            else:
+                # Use the most recent current_ie for all attribute rows
                 row = [getattr(node, attr, "") for attr in self.model.metadata.column_to_attr.values()]
                 row_style = None
                 if colorize:
-                    row_style = (
-                        "yellow"
-                        if self.model._is_include(node)
-                        else "magenta"
-                        if self.model._is_title(node)
-                        else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
-                    )
-                table.add_row(*row, style=row_style)
-
-        self.console.print(table)
+                    if self.model._is_include(node):
+                        row_style = SPECIAL_COLORS["include"]
+                    elif self.model._is_title(node):
+                        row_style = SPECIAL_COLORS["title"]
+                    else:
+                        row_style = LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
+                yield row, row_style, current_module or "Other"

--- a/src/dcmspec/iod_spec_printer.py
+++ b/src/dcmspec/iod_spec_printer.py
@@ -37,8 +37,8 @@ class IODSpecPrinter(SpecPrinter):
             None
 
         """
-        # Disable colorization if outputting to a file
-        use_color = self._should_colorize(colorize)
+        if self.output:
+            colorize = False
 
         for pre, fill, node in RenderTree(self.model.content):
             if node.name == "content":
@@ -49,10 +49,10 @@ class IODSpecPrinter(SpecPrinter):
                 iod_title = getattr(node, "module", getattr(node, "name", ""))
                 iod_usage = getattr(node, "usage", "")
                 iod_title_text = f"{iod_title} Module ({iod_usage})" if iod_usage else iod_title
-                node_text = Text(iod_title_text, style=SPECIAL_COLORS["title"] if use_color else None)
+                node_text = Text(iod_title_text, style=SPECIAL_COLORS["title"] if colorize else None)
             else:
                 attr_text = self._format_tree_row(node, attr_names, attr_widths)
-                row_style = self._get_tree_row_style(node, colorize=use_color)
+                row_style = self._get_tree_row_style(node, colorize)
                 node_text = Text(attr_text, style=row_style)
             self.console.print(Text(pre) + node_text)
 
@@ -72,8 +72,9 @@ class IODSpecPrinter(SpecPrinter):
             colorize (bool): Whether to colorize the output by node depth.
 
         """
-        # Disable colorization if outputting to a file
-        use_color = self._should_colorize(colorize)
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
 
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
@@ -82,7 +83,7 @@ class IODSpecPrinter(SpecPrinter):
             width = column_widths[i] if column_widths and i < len(column_widths) else 20
             table.add_column(header, width=width)
 
-        for row, row_style, _ in self._iterate_rows_iod(colorize=use_color):
+        for row, row_style, _ in self._iterate_rows_iod(colorize):
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
@@ -103,15 +104,16 @@ class IODSpecPrinter(SpecPrinter):
             None
 
         """
-        # Disable colorization if outputting to a file
-        use_color = self._should_colorize(colorize)
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
 
         # Print CSV header
         header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
         self.console.print(header_row)
 
         # Add data rows (including module title rows)
-        for row, row_style, _ in self._iterate_rows_iod(colorize=use_color):
+        for row, row_style, _ in self._iterate_rows_iod(colorize):
             # Escape quotes inside each field by doubling them, then wrap in quotes
             csv_row = ",".join(
                 f'"{("" if cell is None else str(cell)).replace(chr(34), chr(34) + chr(34))}"'
@@ -246,5 +248,7 @@ class IODSpecPrinter(SpecPrinter):
                     elif self.model._is_title(node):
                         row_style = SPECIAL_COLORS["title"]
                     else:
-                        row_style = LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
+                        # use (node.depth - 2) since attributes are children of module nodes,
+                        # which are themselves children of content (root) node
+                        row_style = LEVEL_COLORS[(node.depth - 2) % len(LEVEL_COLORS)]
                 yield row, row_style, current_module or "Other"

--- a/src/dcmspec/iod_spec_printer.py
+++ b/src/dcmspec/iod_spec_printer.py
@@ -37,8 +37,8 @@ class IODSpecPrinter(SpecPrinter):
             None
 
         """
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
 
         for pre, fill, node in RenderTree(self.model.content):
             if node.name == "content":
@@ -49,10 +49,10 @@ class IODSpecPrinter(SpecPrinter):
                 iod_title = getattr(node, "module", getattr(node, "name", ""))
                 iod_usage = getattr(node, "usage", "")
                 iod_title_text = f"{iod_title} Module ({iod_usage})" if iod_usage else iod_title
-                node_text = Text(iod_title_text, style=SPECIAL_COLORS["title"] if colorize else None)
+                node_text = Text(iod_title_text, style=SPECIAL_COLORS["title"] if use_color else None)
             else:
                 attr_text = self._format_tree_row(node, attr_names, attr_widths)
-                row_style = self._get_tree_row_style(node, colorize)
+                row_style = self._get_tree_row_style(node, colorize=use_color)
                 node_text = Text(attr_text, style=row_style)
             self.console.print(Text(pre) + node_text)
 
@@ -72,9 +72,8 @@ class IODSpecPrinter(SpecPrinter):
             colorize (bool): Whether to colorize the output by node depth.
 
         """
-        # Disable colorization if writing to file
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
 
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
@@ -83,7 +82,7 @@ class IODSpecPrinter(SpecPrinter):
             width = column_widths[i] if column_widths and i < len(column_widths) else 20
             table.add_column(header, width=width)
 
-        for row, row_style, _ in self._iterate_rows_iod(colorize):
+        for row, row_style, _ in self._iterate_rows_iod(colorize=use_color):
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
@@ -104,16 +103,15 @@ class IODSpecPrinter(SpecPrinter):
             None
 
         """
-        # Disable colorization if writing to file
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
 
         # Print CSV header
         header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
         self.console.print(header_row)
 
         # Add data rows (including module title rows)
-        for row, row_style, _ in self._iterate_rows_iod(colorize):
+        for row, row_style, _ in self._iterate_rows_iod(colorize=use_color):
             # Escape quotes inside each field by doubling them, then wrap in quotes
             csv_row = ",".join(
                 f'"{("" if cell is None else str(cell)).replace(chr(34), chr(34) + chr(34))}"'

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -5,6 +5,7 @@ from IHE Technical Frameworks or Supplements, returning CSV data from tables in 
 """
 
 import os
+import re
 import logging
 from typing import Optional, List
 # BEGIN LEGACY SUPPORT: Remove for int progress callback deprecation
@@ -18,6 +19,14 @@ import camelot
 from dcmspec.config import Config
 from dcmspec.doc_handler import DocHandler
 from dcmspec.progress import ProgressObserver
+
+# A DICOM tag pattern like "(300A,0230)" appearing in a *header* cell is a strong
+# signal that a data (attribute) row was absorbed into the header — typically
+# because table_header_rowspan over-counts the header rows for a table.
+# select_tables uses this to fail loudly rather than silently drop the row, which
+# is unacceptable for conformance tooling.
+_DICOM_TAG_RE = re.compile(r"\(\s*[0-9A-Fa-f]{4}\s*,\s*[0-9A-Fa-f]{4}\s*\)")
+
 
 class PDFDocHandler(DocHandler):
     """Handler class for extracting tables from PDF documents.
@@ -317,6 +326,19 @@ class PDFDocHandler(DocHandler):
                         header_ = header_rows[0]
                     else:
                         header_ = merge_multirow_header(header_rows)
+                    # Fail loudly if a data row was absorbed into the header: a
+                    # DICOM tag pattern in a header cell means table_header_rowspan
+                    # likely over-counts the header rows for this table, which would
+                    # otherwise silently drop a real attribute row from the spec.
+                    for cell in header_:
+                        if cell and _DICOM_TAG_RE.search(str(cell)):
+                            raise ValueError(
+                                f"Header for table (page {page}, index {idx}) contains a "
+                                f"DICOM tag pattern in cell {cell!r}; a data row was likely "
+                                f"absorbed into the header. Check table_header_rowspan for "
+                                f"(page {page}, index {idx}) — it may exceed the actual "
+                                f"number of header rows."
+                            )
                     selected_tables.append({
                         "page": page,
                         "index": idx,

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -288,6 +288,12 @@ class PDFDocHandler(DocHandler):
                 - 'header': merged header row (list of column names)
                 - 'data': list of data rows (list of cell values)
 
+        Raises:
+            ValueError: If a header cell contains a DICOM tag pattern (e.g. "(300A,0230)"),
+                indicating that a data row was absorbed into the header — typically because
+                table_header_rowspan over-counts the header rows for that table. Failing loudly
+                here prevents silently dropping a real attribute row from the specification.
+
         Example:
             ```python
             selected_tables = handler.select_tables(

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -267,6 +267,7 @@ class PDFDocHandler(DocHandler):
         tables: List[dict],
         table_indices: List[tuple],
         table_header_rowspan: Optional[dict] = None,
+        strict_header_check: bool = True,
     ) -> List[dict]:
         """Select tables referenced by table_indices and split each table into header and data.
 
@@ -280,6 +281,10 @@ class PDFDocHandler(DocHandler):
             table_indices (List[tuple]): List of (page, index) tuples specifying which tables to select and process.
             table_header_rowspan (dict, optional): Number of header rows (rowspan) for each table in table_indices,
                 keyed by (page, index). If not specified, defaults to 1 header row per table.
+            strict_header_check (bool): If True (default), raise ValueError when a header cell
+                contains a DICOM tag pattern — a sign that a data row was absorbed into the header
+                (usually a table_header_rowspan that over-counts the header rows). Set False to skip
+                the check for consumers that prefer the prior warn-and-continue behavior.
 
         Returns:
             List[dict]: List of dicts, each with keys:
@@ -289,7 +294,8 @@ class PDFDocHandler(DocHandler):
                 - 'data': list of data rows (list of cell values)
 
         Raises:
-            ValueError: If a header cell contains a DICOM tag pattern (e.g. "(300A,0230)"),
+            ValueError: If strict_header_check is True (default) and a header cell contains a DICOM
+                tag pattern (e.g. "(300A,0230)"),
                 indicating that a data row was absorbed into the header — typically because
                 table_header_rowspan over-counts the header rows for that table. Failing loudly
                 here prevents silently dropping a real attribute row from the specification.
@@ -336,15 +342,17 @@ class PDFDocHandler(DocHandler):
                     # DICOM tag pattern in a header cell means table_header_rowspan
                     # likely over-counts the header rows for this table, which would
                     # otherwise silently drop a real attribute row from the spec.
-                    for cell in header_:
-                        if cell and _DICOM_TAG_RE.search(str(cell)):
-                            raise ValueError(
-                                f"Header for table (page {page}, index {idx}) contains a "
-                                f"DICOM tag pattern in cell {cell!r}; a data row was likely "
-                                f"absorbed into the header. Check table_header_rowspan for "
-                                f"(page {page}, index {idx}) — it may exceed the actual "
-                                f"number of header rows."
-                            )
+                    # Opt out with strict_header_check=False to keep the prior behavior.
+                    if strict_header_check:
+                        for cell in header_:
+                            if cell and _DICOM_TAG_RE.search(str(cell)):
+                                raise ValueError(
+                                    f"Header for table (page {page}, index {idx}) contains a "
+                                    f"DICOM tag pattern in cell {cell!r}; a data row was likely "
+                                    f"absorbed into the header. Check table_header_rowspan for "
+                                    f"(page {page}, index {idx}) — it may exceed the actual "
+                                    f"number of header rows."
+                                )
                     selected_tables.append({
                         "page": page,
                         "index": idx,

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -56,14 +56,14 @@ class SpecPrinter:
 
     """
 
-    def __init__(self, model: object, output: Optional[str] = None, logger: Optional[logging.Logger] = None) -> None:
+    def __init__(self, model: object, logger: Optional[logging.Logger] = None, output: Optional[str] = None) -> None:
         """Initialize the printer with a specification model and optional output destination.
 
         Args:
             model (object): An instance of SpecModel to render.
-            output (Optional[str]): Path to an output file. If None, defaults to stdout.
             logger (Optional[logging.Logger]): Logger instance for debug/info messages.
-            
+            output (Optional[str]): Path to an output file. If None, defaults to stdout.
+
         """
         self.model = model
         self.output = output

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -4,14 +4,15 @@ Provides the SpecPrinter class for printing DICOM specification models (SpecMode
 to a file or standard output.
 """
 
-from typing import Optional, List, Union
+from typing import Generator, Optional, List, Tuple, Union
 import logging
 
 from rich.console import Console
 from rich.table import Table, box
 from rich.text import Text
-from anytree import RenderTree, PreOrderIter
+from anytree import Node, RenderTree, PreOrderIter
 from openpyxl import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
 LEVEL_COLORS = [
@@ -98,52 +99,22 @@ class SpecPrinter:
         Returns:
             None
 
-        
         Example:
             ```python
             # This will nicely align the tag, type, and name values in the tree output:
             printer.print_tree(attr_names=["elem_tag", "elem_type", "elem_name"], attr_widths=[11, 2, 64])
             ```
-            
+
         """
         # Disable colorization if writing to file
         if self.output:
             colorize = False
-            
+
         for pre, fill, node in RenderTree(self.model.content):
-            color_style = LEVEL_COLORS[node.depth % len(LEVEL_COLORS)] if colorize else "default"
             pre_text = Text(pre)
-
-            if attr_names is None:
-                # Just show the node name, safely handle missing name attribute
-                node_text = Text(str(node.name), style=color_style)
-            else:
-                # Ensure attr_names is a list
-                if isinstance(attr_names, str):
-                    attr_names = [attr_names]
-
-                # Collect attribute values, replacing None with empty string
-                raw_values = []
-                for attr in attr_names:
-                    value = getattr(node, attr, None)
-                    raw_values.append("" if value is None else str(value))
-
-                # Apply padding/truncation if attr_widths is provided
-                if attr_widths:
-                    padded_values = []
-                    for v, w in zip(raw_values, attr_widths):
-                        if w is not None:
-                            padded_values.append(v.ljust(w)[:w])
-                        else:
-                            padded_values.append(v)
-                    values = padded_values
-                else:
-                    values = raw_values
-
-                # Join values into a single string and remove leading spaces
-                attr_text = " ".join(values).lstrip()
-                node_text = Text(attr_text, style=color_style)
-
+            attr_text = self._format_tree_row(node, attr_names, attr_widths)
+            row_style = self._get_tree_row_style(node, colorize)
+            node_text = Text(attr_text, style=row_style)
             self.console.print(pre_text + node_text)
 
         if self.console.file:
@@ -248,7 +219,8 @@ class SpecPrinter:
             raise ValueError("Output file path must be specified when constructing SpecPrinter for print_xlsx).")
 
         header_style, data_style = self._create_styles()
-        wb, ws = self._setup_workbook("Specification")
+        wb = self._setup_workbook()
+        ws = self._setup_worksheet(wb, "Specification")    
 
         self._write_headers(ws, self.model.metadata.header, header_style)
         if column_widths:
@@ -257,7 +229,7 @@ class SpecPrinter:
         self._write_data_rows(ws, self._iterate_rows(colorize=colorize), data_style, colorize)
         wb.save(self.output)
 
-    def _create_styles(self):
+    def _create_styles(self) -> Tuple[dict, dict]:
         border = Border(
             left=Side(style="thin", color="B3B3B3"),
             right=Side(style="thin", color="B3B3B3"),
@@ -278,23 +250,33 @@ class SpecPrinter:
         }
         return header_style, data_style
 
-    def _setup_workbook(self, title: str):
+    def _setup_workbook(self) -> Workbook:
         wb = Workbook()
-        ws = wb.active
-        ws.title = title
-        return wb, ws
+        # Remove the default sheet if it exists
+        if "Sheet" in wb.sheetnames:
+            wb.remove(wb["Sheet"])
+        return wb
+    
+    def _setup_worksheet(self, wb: Workbook, title: str) -> Worksheet:
+        return wb.create_sheet(title=title)
 
-    def _write_headers(self, ws, headers, style):
+    def _write_headers(self, ws: Worksheet, headers: List[str], style: dict) -> None:
         ws.append(headers)
         for cell in ws[1]:
             self._apply_style(cell, style)
 
-    def _set_column_widths(self, ws, widths):
+    def _set_column_widths(self, ws: Worksheet, widths: List[int]) -> None:
         from openpyxl.utils import get_column_letter
         for idx, width in enumerate(widths, start=1):
             ws.column_dimensions[get_column_letter(idx)].width = width
 
-    def _write_data_rows(self, ws, rows, style, colorize):
+    def _write_data_rows(
+            self, 
+            ws: Worksheet, 
+            rows: Generator[Tuple[List[str], Optional[str]], None, None], 
+            style: dict, 
+            colorize: bool
+            ) -> None:
         for row, row_style in rows:
             current_row = ws.max_row + 1
             for col_idx, value in enumerate(row, start=1):
@@ -308,7 +290,7 @@ class SpecPrinter:
                                             fill_type="solid")
                     
     @staticmethod
-    def _apply_style(cell, style_dict):
+    def _apply_style(cell, style_dict) -> None:
         """Apply a style dictionary (font, alignment, fill, border) to a cell."""
         for attr, value in style_dict.items():
             setattr(cell, attr, value)
@@ -320,7 +302,7 @@ class SpecPrinter:
         # Prepend 'FF' for opaque alpha channel as openpyxl expects ARGB
         return "FF{:02X}{:02X}{:02X}".format(*map(int, rgb))
 
-    def _iterate_rows(self, colorize: bool = False):
+    def _iterate_rows(self, colorize: bool = False) -> Generator[Tuple[List[str], Optional[str]], None, None]:
         """Generate rows from the model tree with optional styling.
 
         Args:
@@ -352,7 +334,70 @@ class SpecPrinter:
             
             yield row, row_style
 
-    def __del__(self):
+    def _format_tree_row(
+            self, 
+            node: Node, 
+            attr_names: Optional[Union[str, List[str]]] = None, 
+            attr_widths: Optional[List[int]] = None
+            ) -> str:
+        """Format the text for a node in tree output.
+
+        Args:
+            node: The node to display.
+            attr_names (Optional[Union[str, list[str]]]): Attribute name(s) to display for each node.
+            attr_widths (Optional[list[int]]): List of widths for each attribute in attr_names.
+
+        Returns:
+            str: The formatted text for the node.
+
+        """
+        if attr_names is None:
+            # Just show the node name, safely handle missing name attribute
+            return str(node.name)
+        # Ensure attr_names is a list
+        attr_names_list = [attr_names] if isinstance(attr_names, str) else attr_names
+        # Collect attribute values, replacing None with empty string
+        raw_values = []
+        for attr in attr_names_list:
+            value = getattr(node, attr, None)
+            raw_values.append("" if value is None else str(value))
+
+        if attr_widths:
+            # Apply padding/truncation
+            padded_values = []
+            for v, w in zip(raw_values, attr_widths):
+                if w is None:
+                    padded_values.append(v)
+                else:
+                    padded_values.append(v.ljust(w)[:w])
+            values = padded_values
+        else:
+            values = raw_values
+
+        # Join values into a single string and remove leading spaces
+        return " ".join(values).lstrip()
+
+    def _get_tree_row_style(self, node: Node, colorize: bool = False) -> Optional[str]:
+        """Determine the style for a node in tree output.
+
+        Args:
+            node: The node to display.
+            colorize (bool): Whether to colorize the output by node depth.
+
+        Returns:
+            str or None: The style string for the node, or None if not colorized.
+            
+        """
+        if not colorize:
+            return "default"
+        if hasattr(self.model, "_is_include") and self.model._is_include(node):
+            return SPECIAL_COLORS["include"]
+        elif hasattr(self.model, "_is_title") and self.model._is_title(node):
+            return SPECIAL_COLORS["title"]
+        else:
+            return LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
+
+    def __del__(self) -> None:
         """Close output file when the printer is deleted, if opened."""
         output = getattr(self, "output", None)
         console = getattr(self, "console", None)

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -16,13 +16,14 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
 LEVEL_COLORS = [
-    "rgb(176,224,230)",  # Root: Powder Blue
-    "rgb(135,206,250)",  # Level 1: Sky Blue
-    "rgb(0,191,255)",    # Level 2: Deep Sky Blue
-    "rgb(30,144,255)",   # Level 3: Dodger Blue
-    "rgb(0,0,255)",      # Level 4: Blue
-    "rgb(0,0,205)",      # Level 5: Medium Blue
-    "rgb(0,0,139)",      # Level 6: Dark Blue
+    "rgb(176,224,230)",   # Root: Powder Blue
+    "rgb(135,206,250)",   # Level 1: Sky Blue
+    "rgb(0,191,255)",     # Level 2: Deep Sky Blue
+    "rgb(30,144,255)",    # Level 3: Dodger Blue
+    "rgb(65,105,225)",    # Level 4: Royal Blue
+    "rgb(106,90,205)",    # Level 5: Slate Blue
+    "rgb(123,104,238)",   # Level 7: Medium Slate Blue
+    "rgb(147,112,219)",   # Level 8: Medium Purple
 ]
 
 SPECIAL_COLORS = {

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -16,14 +16,14 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
 LEVEL_COLORS = [
-    "rgb(176,224,230)",   # Root: Powder Blue
-    "rgb(135,206,250)",   # Level 1: Sky Blue
-    "rgb(0,191,255)",     # Level 2: Deep Sky Blue
-    "rgb(30,144,255)",    # Level 3: Dodger Blue
-    "rgb(65,105,225)",    # Level 4: Royal Blue
-    "rgb(106,90,205)",    # Level 5: Slate Blue
-    "rgb(123,104,238)",   # Level 7: Medium Slate Blue
-    "rgb(147,112,219)",   # Level 8: Medium Purple
+    "rgb(176,224,230)",   # Nesting Level 0: Powder Blue        (hex #B0E0E6)
+    "rgb(135,206,250)",   # Nesting Level 1: Sky Blue           (hex #87CEFA)
+    "rgb(0,191,255)",     # Nesting Level 2: Deep Sky Blue      (hex #00BFFF)
+    "rgb(30,144,255)",    # Nesting Level 3: Dodger Blue        (hex #1E90FF)
+    "rgb(65,105,225)",    # Nesting Level 4: Royal Blue         (hex #4169E1)
+    "rgb(106,90,205)",    # Nesting Level 5: Slate Blue         (hex #6A5ACD)
+    "rgb(123,104,238)",   # Nesting Level 6: Medium Slate Blue  (hex #7B68EE)
+    "rgb(147,112,219)",   # Nesting Level 7: Medium Purple      (hex #9370DB)
 ]
 
 SPECIAL_COLORS = {
@@ -333,6 +333,7 @@ class SpecPrinter:
                 elif self.model._is_title(node):
                     row_style = SPECIAL_COLORS["title"]
                 else:
+                    # use (node.depth - 1) since attributes are direct children of the content (root) node       
                     row_style = LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
             
             yield row, row_style
@@ -392,7 +393,7 @@ class SpecPrinter:
             
         """
         if not colorize:
-            return "default"
+            return None
         if hasattr(self.model, "_is_include") and self.model._is_include(node):
             return SPECIAL_COLORS["include"]
         elif hasattr(self.model, "_is_title") and self.model._is_title(node):

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -107,14 +107,13 @@ class SpecPrinter:
             ```
 
         """
-        # Disable colorization if writing to file
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
 
         for pre, fill, node in RenderTree(self.model.content):
             pre_text = Text(pre)
             attr_text = self._format_tree_row(node, attr_names, attr_widths)
-            row_style = self._get_tree_row_style(node, colorize)
+            row_style = self._get_tree_row_style(node, use_color)
             node_text = Text(attr_text, style=row_style)
             self.console.print(pre_text + node_text)
 
@@ -141,9 +140,8 @@ class SpecPrinter:
             None
             
         """
-        # Disable colorization if writing to file
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
             
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
@@ -153,7 +151,7 @@ class SpecPrinter:
             table.add_column(header, width=width)
 
         # Add rows to the table
-        for row, row_style in self._iterate_rows(colorize):
+        for row, row_style in self._iterate_rows(colorize=use_color):
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
@@ -174,16 +172,15 @@ class SpecPrinter:
             None
             
         """
-        # Disable colorization if writing to file
-        if self.output:
-            colorize = False
+        # Disable colorization if outputting to a file
+        use_color = self._should_colorize(colorize)
             
         # Print CSV header
         header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
         self.console.print(header_row)
 
         # Add data rows
-        for row, row_style in self._iterate_rows(colorize):
+        for row, row_style in self._iterate_rows(colorize=use_color):
             # Escape quotes inside each field by doubling them 
             # (e.g., Include Table 10.29-1 "UDI Macro Attributes"→ Include Table 10.29-1 ""UDI Macro Attributes""),
             # then wrap the entire field in quotes for proper CSV formatting
@@ -250,6 +247,11 @@ class SpecPrinter:
             "border": border
         }
         return header_style, data_style
+
+
+    def _should_colorize(self, colorize: bool) -> bool:
+        """Determine whether colorization should be applied."""
+        return colorize and not self.output
 
     def _setup_workbook(self) -> Workbook:
         wb = Workbook()

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -3,21 +3,31 @@
 Provides the SpecPrinter class for printing DICOM specification models (SpecModel)
 to a file or standard output.
 """
+
+from typing import Optional, List, Union
+import logging
+
 from rich.console import Console
 from rich.table import Table, box
 from rich.text import Text
 from anytree import RenderTree, PreOrderIter
-from typing import Optional, List, Union
-import logging
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 
 LEVEL_COLORS = [
-    "rgb(255,255,255)",  # Node depth 0, Root: White
-    "rgb(173,216,230)",  # Node depth 1, Table Level 0: Light Blue
-    "rgb(135,206,250)",  # Node depth 2, Table Level 1: Sky Blue
-    "rgb(0,191,255)",  # Node depth 3, Table Level 2: Deep Sky Blue
-    "rgb(30,144,255)",  # Node depth 4, Table Level 3: Dodger Blue
-    "rgb(0,0,255)",  # Node depth 5, Table Level 4: Blue
+    "rgb(176,224,230)",  # Root: Powder Blue
+    "rgb(135,206,250)",  # Level 1: Sky Blue
+    "rgb(0,191,255)",    # Level 2: Deep Sky Blue
+    "rgb(30,144,255)",   # Level 3: Dodger Blue
+    "rgb(0,0,255)",      # Level 4: Blue
+    "rgb(0,0,205)",      # Level 5: Medium Blue
+    "rgb(0,0,139)",      # Level 6: Dark Blue
 ]
+
+SPECIAL_COLORS = {
+    "include": "rgb(255,255,135)",  # Yellow for include nodes
+    "title": "rgb(255,0,255)",    # Magenta for title nodes
+}
 
 class SpecPrinter:
     """Printer for DICOM specification models.
@@ -53,13 +63,14 @@ class SpecPrinter:
             logger (Optional[logging.Logger]): Logger instance for debug/info messages.
             
         """
+        self.model = model
+        self.output = output
+        self.console = None  # ensure attribute exists even if validation raises
+
         if logger is not None and not isinstance(logger, logging.Logger):
             raise TypeError("logger must be an instance of logging.Logger or None")
         self.logger = logger or logging.getLogger(self.__class__.__name__)
 
-        self.model = model
-        self.output = output
-        # Disable styling when writing to file
         self.console = Console(
             highlight=False,
             file=open(output, "w", encoding="utf-8") if output else None,
@@ -210,6 +221,102 @@ class SpecPrinter:
         if self.console.file:
             self.console.file.flush()  # Ensure data is written immediately
 
+    def print_xlsx(self, output:str, column_widths: Optional[List[int]] = None, colorize: bool = False) -> None:
+        """Print the specification model to an OOXML format Excel (.xlsx) file.
+
+        Traverses the content tree and writes each node's attributes into an Excel sheet,
+        with column headers from the metadata node. Handles newlines and applies background
+        colorization using the same color scheme as console output (LEVEL_COLORS).
+
+        Args:
+            output (str): Path to the Excel file to write. Required.
+            column_widths (list): Optional list of column widths for Excel columns.
+            colorize (bool): Whether to apply color styling to cell backgrounds.
+
+        Returns:
+            None
+
+            
+        Note:
+            All values are written as text to preserve DICOM identifiers and prevent unintended
+            numeric conversion. Excel may still display a 'Number stored as text' warning for
+            values that look numeric. This is expected and harmless. To suppress it:
+            - On Windows: File → Options → Formulas → Error Checking → Uncheck "Numbers stored as text".
+            - On macOS: Excel → Preferences → Error Checking → Uncheck "Numbers formatted as text".
+
+        """
+        header_style, data_style = self._create_styles()
+        wb, ws = self._setup_workbook("Specification")
+
+        self._write_headers(ws, self.model.metadata.header, header_style)
+        if column_widths:
+            self._set_column_widths(ws, column_widths)
+
+        self._write_data_rows(ws, self._iterate_rows(colorize=colorize), data_style, colorize)
+        wb.save(output)
+
+    def _create_styles(self):
+        border = Border(
+            left=Side(style="thin", color="B3B3B3"),
+            right=Side(style="thin", color="B3B3B3"),
+            top=Side(style="thin", color="B3B3B3"),
+            bottom=Side(style="thin", color="B3B3B3")
+        )
+        alignment = Alignment(wrap_text=True, vertical="top")
+        header_style = {
+            "font": Font(bold=True, name="Consolas"),
+            "alignment": alignment,
+            "fill": PatternFill(start_color="F2F2F2", end_color="F2F2F2", fill_type="solid"),
+            "border": border
+        }
+        data_style = {
+            "font": Font(name="Consolas"),
+            "alignment": alignment,
+            "border": border
+        }
+        return header_style, data_style
+
+    def _setup_workbook(self, title: str):
+        wb = Workbook()
+        ws = wb.active
+        ws.title = title
+        return wb, ws
+
+    def _write_headers(self, ws, headers, style):
+        ws.append(headers)
+        for cell in ws[1]:
+            self._apply_style(cell, style)
+
+    def _set_column_widths(self, ws, widths):
+        from openpyxl.utils import get_column_letter
+        for idx, width in enumerate(widths, start=1):
+            ws.column_dimensions[get_column_letter(idx)].width = width
+
+    def _write_data_rows(self, ws, rows, style, colorize):
+        for row, row_style in rows:
+            current_row = ws.max_row + 1
+            for col_idx, value in enumerate(row, start=1):
+                cell = ws.cell(row=current_row, column=col_idx)
+                cell.number_format = '@'
+                cell.value = str(value)
+                self._apply_style(cell, style)
+                if colorize and row_style:
+                    cell.fill = PatternFill(start_color=self._rgb_to_hex(row_style),
+                                            end_color=self._rgb_to_hex(row_style),
+                                            fill_type="solid")
+                    
+    @staticmethod
+    def _apply_style(cell, style_dict):
+        """Apply a style dictionary (font, alignment, fill, border) to a cell."""
+        for attr, value in style_dict.items():
+            setattr(cell, attr, value)
+
+    @staticmethod
+    def _rgb_to_hex(rgb_str: str) -> str:
+        """Convert an RGB string like 'rgb(255,255,0)' to HEX format."""
+        rgb = rgb_str.replace("rgb(", "").replace(")", "").split(",")
+        return "{:02X}{:02X}{:02X}".format(*map(int, rgb))
+
     def _iterate_rows(self, colorize: bool = False):
         """Generate rows from the model tree with optional styling.
 
@@ -218,7 +325,8 @@ class SpecPrinter:
 
         Yields:
             tuple: (row_data, row_style) where row_data is a list of cell values
-                    and row_style is the color style string or None.
+                    and row_style is an RGB color string (e.g., "rgb(255,255,0)") 
+                    from LEVEL_COLORS or SPECIAL_COLORS, or None if not colorized.
 
         """
         for node in PreOrderIter(self.model.content):
@@ -232,17 +340,23 @@ class SpecPrinter:
                 continue
             row_style = None
             if colorize:
-                row_style = (
-                    "yellow"
-                    if self.model._is_include(node)
-                    else "magenta"
-                    if self.model._is_title(node)
-                    else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
-                )
+                if self.model._is_include(node):
+                    row_style = SPECIAL_COLORS["include"]
+                elif self.model._is_title(node):
+                    row_style = SPECIAL_COLORS["title"]
+                else:
+                    row_style = LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
             
             yield row, row_style
 
     def __del__(self):
         """Close output file when the printer is deleted, if opened."""
-        if self.output and hasattr(self.console, 'file') and self.console.file:
-            self.console.file.close()
+        output = getattr(self, "output", None)
+        console = getattr(self, "console", None)
+        file_obj = getattr(console, "file", None) if console else None
+        if output and file_obj:
+            try:
+                if not file_obj.closed:
+                    file_obj.close()
+            except Exception:
+                pass

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -1,7 +1,7 @@
 """Printer class for specification model in dcmspec.
 
 Provides the SpecPrinter class for printing DICOM specification models (SpecModel)
-to standard output, either as a hierarchical tree or as a flat table, using rich formatting.
+to a file or standard output.
 """
 from rich.console import Console
 from rich.table import Table, box
@@ -22,24 +22,48 @@ LEVEL_COLORS = [
 class SpecPrinter:
     """Printer for DICOM specification models.
 
-    Provides methods to print a SpecModel as a hierarchical tree or as a flat table,
-    using rich formatting for console output. Supports colorized output and customizable logging.
+    Provides methods to render a SpecModel in multiple formats:
+    - Hierarchical tree (ASCII)
+    - Flat table (ASCII, using Rich for styling)
+    - CSV (plain text)
+
+    Output can be directed to the console (default) or to a file by specifying
+    an output path when initializing the printer. Rich formatting is used for
+    tree and table views when writing to the console; when writing to a file,
+    plain text is used.
+
+    Responsibilities:
+    - Encapsulates all presentation logic for SpecModel.
+    - Supports colorized output for better readability.
+    - Handles output destination internally (stdout or file).
+
+    Args:
+        model (SpecModel): The specification model to print.
+        output (Optional[str]): Path to an output file. If None, prints to stdout.
+        logger (Optional[logging.Logger]): Logger instance for debug/info messages.
     """
 
-    def __init__(self, model: object, logger: Optional[logging.Logger] = None) -> None:
-        """Initialize the input handler with an optional logger.
+    def __init__(self, model: object, output: Optional[str] = None, logger: Optional[logging.Logger] = None) -> None:
+        """Initialize the printer with a specification model and optional output destination.
 
         Args:
-            model (object): An instance of SpecModel.
-            logger (Optional[logging.Logger]): Logger instance to use. If None, a default logger is created.
-
+            model (object): An instance of SpecModel to render.
+            output (Optional[str]): Path to an output file. If None, defaults to stdout.
+            logger (Optional[logging.Logger]): Logger instance for debug/info messages.
         """
         if logger is not None and not isinstance(logger, logging.Logger):
             raise TypeError("logger must be an instance of logging.Logger or None")
         self.logger = logger or logging.getLogger(self.__class__.__name__)
 
         self.model = model
-        self.console = Console(highlight=False)
+        self.output = output
+        # Disable styling when writing to file
+        self.console = Console(
+            highlight=False,
+            file=open(output, "w", encoding="utf-8") if output else None,
+            force_terminal=not output,
+            no_color=bool(output)
+        )
 
     def print_tree(
         self,
@@ -47,7 +71,7 @@ class SpecPrinter:
         attr_widths: Optional[List[int]] = None,
         colorize: bool = False,
     ) -> None:
-        """Print the specification model as a hierarchical tree to the console.
+        """Print the specification model as a hierarchical tree to the console or file.
 
         Args:
             attr_names (Optional[Union[str, list[str]]]): Attribute name(s) to display for each node.
@@ -56,7 +80,7 @@ class SpecPrinter:
                 If a list of strings, displays all specified attributes.
             attr_widths (Optional[list[int]]): List of widths for each attribute in attr_names.
                 If provided, each attribute will be padded/truncated to the specified width.
-            colorize (bool): Whether to colorize the output by node depth.
+            colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
 
         Returns:
             None
@@ -69,6 +93,10 @@ class SpecPrinter:
             ```
             
         """
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
+            
         for pre, fill, node in RenderTree(self.model.content):
             style = LEVEL_COLORS[node.depth % len(LEVEL_COLORS)] if colorize else "default"
             pre_text = Text(pre)
@@ -89,65 +117,73 @@ class SpecPrinter:
             self.console.print(pre_text + node_text)
 
     def print_table(self, colorize: bool = False) -> None:
-        """Print the specification model as an ascii table to the console
+        """Print the specification model as an ascii table to the console or file.
 
         Traverses the content tree and prints each node's attributes in a flat table,
         using column headers from the metadata node. Optionally colorizes rows.
 
         Args:
-            colorize (bool): Whether to colorize the output by node depth.
+            colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
 
         Returns:
             None
             
         """
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
+            
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
         # Define the columns using the extracted headers
         for header in self.model.metadata.header:
             table.add_column(header, width=20)
 
-        # Traverse the tree and add rows to the table
-        for node in PreOrderIter(self.model.content):
-            # skip the root node
-            if node.name == "content":
-                continue
-            
-            row = [getattr(node, attr, "") for attr in self.model.metadata.column_to_attr.values()]
-            # Skip row if all values are empty or whitespace
-            if all(not str(cell).strip() for cell in row):
-                continue
-            row_style = None
-            if colorize:
-                row_style = (
-                    "yellow"
-                    if self.model._is_include(node)
-                    else "magenta"
-                    if self.model._is_title(node)
-                    else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
-                )
+        # Add rows to the table
+        for row, row_style in self._iterate_rows(colorize):
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
 
     def print_csv(self, colorize: bool = False) -> None:
-        """Print the specification model as CSV to the console.
+        """Print the specification model as CSV to the console or file.
 
         Traverses the content tree and prints each node's attributes in CSV format,
         with column headers from the metadata node. Optionally colorizes rows.
 
         Args:
-            colorize (bool): Whether to colorize the output by node depth.
+            colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
 
         Returns:
             None
             
         """
+        # Disable colorization if writing to file
+        if self.output:
+            colorize = False
+            
         # Print CSV header
         header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
         self.console.print(header_row)
 
-        # Traverse the tree and print rows
+        # Add data rows
+        for row, row_style in self._iterate_rows(colorize):
+            # Escape quotes inside each field by doubling them 
+            # (e.g., Include Table 10.29-1 "UDI Macro Attributes"→ Include Table 10.29-1 ""UDI Macro Attributes""),
+            # then wrap the entire field in quotes for proper CSV formatting
+            csv_row = ",".join(f'"{cell.replace(chr(34), chr(34) + chr(34))}"' for cell in row)
+            self.console.print(csv_row, style=row_style)
+
+    def _iterate_rows(self, colorize: bool = False):
+        """Generate rows from the model tree with optional styling.
+
+        Args:
+            colorize (bool): Whether to apply color styling to rows.
+
+        Yields:
+            tuple: (row_data, row_style) where row_data is a list of cell values
+                   and row_style is the color style string or None.
+        """
         for node in PreOrderIter(self.model.content):
             # skip the root node
             if node.name == "content":
@@ -158,11 +194,6 @@ class SpecPrinter:
             if all(not cell.strip() for cell in row):
                 continue
 
-            # Escape quotes inside each field by doubling them 
-            # (e.g., Include Table 10.29-1 “UDI Macro Attributes”→ Include Table 10.29-1 “”UDI Macro Attributes””),
-            # then wrap the entire field in quotes for proper CSV formattin
-            csv_row = ",".join(f'"{cell.replace(chr(34), chr(34) + chr(34))}"' for cell in row)
-            
             row_style = None
             if colorize:
                 row_style = (
@@ -173,4 +204,9 @@ class SpecPrinter:
                     else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
                 )
             
-            self.console.print(csv_row, style=row_style)
+            yield row, row_style
+
+    def __del__(self):
+        """Close output file when the printer is deleted, if opened."""
+        if self.output and hasattr(self.console, 'file') and self.console.file:
+            self.console.file.close()

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -89,7 +89,7 @@ class SpecPrinter:
             self.console.print(pre_text + node_text)
 
     def print_table(self, colorize: bool = False) -> None:
-        """Print the specification model as a flat table to the console.
+        """the specification model as an ascii table to the console
 
         Traverses the content tree and prints each node's attributes in a flat table,
         using column headers from the metadata node. Optionally colorizes rows.
@@ -129,3 +129,48 @@ class SpecPrinter:
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
+
+    def print_csv(self, colorize: bool = False) -> None:
+        """Print the specification model as CSV to the console.
+
+        Traverses the content tree and prints each node's attributes in CSV format,
+        with column headers from the metadata node. Optionally colorizes rows.
+
+        Args:
+            colorize (bool): Whether to colorize the output by node depth.
+
+        Returns:
+            None
+            
+        """
+        # Print CSV header
+        header_row = ",".join(f'"{h}"' for h in self.model.metadata.header)
+        self.console.print(header_row)
+
+        # Traverse the tree and print rows
+        for node in PreOrderIter(self.model.content):
+            # skip the root node
+            if node.name == "content":
+                continue
+            
+            row = [str(getattr(node, attr, "")) for attr in self.model.metadata.column_to_attr.values()]
+            # Skip row if all values are empty or whitespace
+            if all(not cell.strip() for cell in row):
+                continue
+
+            # Escape quotes inside each field by doubling them 
+            # (e.g., Include Table 10.29-1 “UDI Macro Attributes”→ Include Table 10.29-1 “”UDI Macro Attributes””),
+            # then wrap the entire field in quotes for proper CSV formattin
+            csv_row = ",".join(f'"{cell.replace(chr(34), chr(34) + chr(34))}"' for cell in row)
+            
+            row_style = None
+            if colorize:
+                row_style = (
+                    "yellow"
+                    if self.model._is_include(node)
+                    else "magenta"
+                    if self.model._is_title(node)
+                    else LEVEL_COLORS[(node.depth - 1) % len(LEVEL_COLORS)]
+                )
+            
+            self.console.print(csv_row, style=row_style)

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -100,22 +100,39 @@ class SpecPrinter:
             colorize = False
             
         for pre, fill, node in RenderTree(self.model.content):
-            style = LEVEL_COLORS[node.depth % len(LEVEL_COLORS)] if colorize else "default"
+            color_style = LEVEL_COLORS[node.depth % len(LEVEL_COLORS)] if colorize else "default"
             pre_text = Text(pre)
+
             if attr_names is None:
-                node_text = Text(str(node.name), style=style)
+                # Just show the node name, safely handle missing name attribute
+                node_text = Text(str(node.name), style=color_style)
             else:
+                # Ensure attr_names is a list
                 if isinstance(attr_names, str):
                     attr_names = [attr_names]
-                values = [str(getattr(node, attr, "")) for attr in attr_names]
+
+                # Collect attribute values, replacing None with empty string
+                raw_values = []
+                for attr in attr_names:
+                    value = getattr(node, attr, None)
+                    raw_values.append("" if value is None else str(value))
+
+                # Apply padding/truncation if attr_widths is provided
                 if attr_widths:
-                    # Pad/truncate each value to the specified width
-                    values = [
-                        v.ljust(w)[:w] if w is not None else v
-                        for v, w in zip(values, attr_widths)
-                    ]
-                attr_text = " ".join(values)
-                node_text = Text(attr_text, style=style)
+                    padded_values = []
+                    for v, w in zip(raw_values, attr_widths):
+                        if w is not None:
+                            padded_values.append(v.ljust(w)[:w])
+                        else:
+                            padded_values.append(v)
+                    values = padded_values
+                else:
+                    values = raw_values
+
+                # Join values into a single string and remove leading spaces
+                attr_text = " ".join(values).lstrip()
+                node_text = Text(attr_text, style=color_style)
+
             self.console.print(pre_text + node_text)
 
         if self.console.file:

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -41,6 +41,7 @@ class SpecPrinter:
         model (SpecModel): The specification model to print.
         output (Optional[str]): Path to an output file. If None, prints to stdout.
         logger (Optional[logging.Logger]): Logger instance for debug/info messages.
+
     """
 
     def __init__(self, model: object, output: Optional[str] = None, logger: Optional[logging.Logger] = None) -> None:
@@ -50,6 +51,7 @@ class SpecPrinter:
             model (object): An instance of SpecModel to render.
             output (Optional[str]): Path to an output file. If None, defaults to stdout.
             logger (Optional[logging.Logger]): Logger instance for debug/info messages.
+            
         """
         if logger is not None and not isinstance(logger, logging.Logger):
             raise TypeError("logger must be an instance of logging.Logger or None")
@@ -191,14 +193,15 @@ class SpecPrinter:
 
         Yields:
             tuple: (row_data, row_style) where row_data is a list of cell values
-                   and row_style is the color style string or None.
+                    and row_style is the color style string or None.
+
         """
         for node in PreOrderIter(self.model.content):
             # skip the root node
             if node.name == "content":
                 continue
             
-            row = [str(getattr(node, attr, "")) for attr in self.model.metadata.column_to_attr.values()]
+            row = [str(getattr(node, attr, "") or "") for attr in self.model.metadata.column_to_attr.values()]
             # Skip row if all values are empty or whitespace
             if all(not str(cell).strip() for cell in row):
                 continue

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -221,7 +221,7 @@ class SpecPrinter:
         if self.console.file:
             self.console.file.flush()  # Ensure data is written immediately
 
-    def print_xlsx(self, output:str, column_widths: Optional[List[int]] = None, colorize: bool = False) -> None:
+    def print_xlsx(self, column_widths: Optional[List[int]] = None, colorize: bool = False) -> None:
         """Print the specification model to an OOXML format Excel (.xlsx) file.
 
         Traverses the content tree and writes each node's attributes into an Excel sheet,
@@ -229,7 +229,6 @@ class SpecPrinter:
         colorization using the same color scheme as console output (LEVEL_COLORS).
 
         Args:
-            output (str): Path to the Excel file to write. Required.
             column_widths (list): Optional list of column widths for Excel columns.
             colorize (bool): Whether to apply color styling to cell backgrounds.
 
@@ -245,6 +244,9 @@ class SpecPrinter:
             - On macOS: Excel → Preferences → Error Checking → Uncheck "Numbers formatted as text".
 
         """
+        if not self.output:
+            raise ValueError("Output file path must be specified when constructing SpecPrinter for print_xlsx).")
+
         header_style, data_style = self._create_styles()
         wb, ws = self._setup_workbook("Specification")
 
@@ -253,7 +255,7 @@ class SpecPrinter:
             self._set_column_widths(ws, column_widths)
 
         self._write_data_rows(ws, self._iterate_rows(colorize=colorize), data_style, colorize)
-        wb.save(output)
+        wb.save(self.output)
 
     def _create_styles(self):
         border = Border(
@@ -313,9 +315,10 @@ class SpecPrinter:
 
     @staticmethod
     def _rgb_to_hex(rgb_str: str) -> str:
-        """Convert an RGB string like 'rgb(255,255,0)' to HEX format."""
+        """Convert an RGB string like 'rgb(255,255,0)' to ARGB hex format (e.g., 'FFFF00FF')."""
         rgb = rgb_str.replace("rgb(", "").replace(")", "").split(",")
-        return "{:02X}{:02X}{:02X}".format(*map(int, rgb))
+        # Prepend 'FF' for opaque alpha channel as openpyxl expects ARGB
+        return "FF{:02X}{:02X}{:02X}".format(*map(int, rgb))
 
     def _iterate_rows(self, colorize: bool = False):
         """Generate rows from the model tree with optional styling.

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -116,6 +116,9 @@ class SpecPrinter:
                 node_text = Text(attr_text, style=style)
             self.console.print(pre_text + node_text)
 
+        if self.console.file:
+            self.console.file.flush()  # Ensure data is written immediately
+
     def print_table(self, colorize: bool = False) -> None:
         """Print the specification model as an ascii table to the console or file.
 
@@ -144,6 +147,9 @@ class SpecPrinter:
             table.add_row(*row, style=row_style)
 
         self.console.print(table)
+        
+        if self.console.file:
+            self.console.file.flush()  # Ensure data is written immediately
 
     def print_csv(self, colorize: bool = False) -> None:
         """Print the specification model as CSV to the console or file.
@@ -174,6 +180,9 @@ class SpecPrinter:
             csv_row = ",".join(f'"{cell.replace(chr(34), chr(34) + chr(34))}"' for cell in row)
             self.console.print(csv_row, style=row_style)
 
+        if self.console.file:
+            self.console.file.flush()  # Ensure data is written immediately
+
     def _iterate_rows(self, colorize: bool = False):
         """Generate rows from the model tree with optional styling.
 
@@ -191,9 +200,8 @@ class SpecPrinter:
             
             row = [str(getattr(node, attr, "")) for attr in self.model.metadata.column_to_attr.values()]
             # Skip row if all values are empty or whitespace
-            if all(not cell.strip() for cell in row):
+            if all(not str(cell).strip() for cell in row):
                 continue
-
             row_style = None
             if colorize:
                 row_style = (

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -138,13 +138,20 @@ class SpecPrinter:
         if self.console.file:
             self.console.file.flush()  # Ensure data is written immediately
 
-    def print_table(self, colorize: bool = False) -> None:
+    def print_table(self, column_widths: Optional[List[int]] = None, colorize: bool = False) -> None:
         """Print the specification model as an ascii table to the console or file.
 
         Traverses the content tree and prints each node's attributes in a flat table,
         using column headers from the metadata node. Optionally colorizes rows.
 
+
         Args:
+            column_widths (Optional[List[int]]): List of widths for each column's **content**.
+                These widths do not include borders or padding added by Rich.
+                If provided, each column will be set to the specified content width.
+                If None, all columns default to width 20.            
+                If the list is shorter than the number of columns, remaining columns default to width 20.
+
             colorize (bool): Whether to colorize the output by node depth. Ignored when writing to file.
 
         Returns:
@@ -158,8 +165,9 @@ class SpecPrinter:
         table = Table(show_header=True, header_style="bold magenta", show_lines=True, box=box.ASCII_DOUBLE_HEAD)
 
         # Define the columns using the extracted headers
-        for header in self.model.metadata.header:
-            table.add_column(header, width=20)
+        for i, header in enumerate(self.model.metadata.header):
+            width = column_widths[i] if column_widths and i < len(column_widths) else 20
+            table.add_column(header, width=width)
 
         # Add rows to the table
         for row, row_style in self._iterate_rows(colorize):

--- a/src/dcmspec/spec_printer.py
+++ b/src/dcmspec/spec_printer.py
@@ -89,7 +89,7 @@ class SpecPrinter:
             self.console.print(pre_text + node_text)
 
     def print_table(self, colorize: bool = False) -> None:
-        """the specification model as an ascii table to the console
+        """Print the specification model as an ascii table to the console
 
         Traverses the content tree and prints each node's attributes in a flat table,
         using column headers from the metadata node. Optionally colorizes rows.

--- a/tests/fixtures_dom_tables.py
+++ b/tests/fixtures_dom_tables.py
@@ -338,11 +338,11 @@ def table_include_dom():
                                 </tr>
                                 <tr valign="top">
                                     <td align="left" colspan="4" rowspan="1">
-                                        <p>
-                                            <span class="italic">
-                                                Include <a class="xref" href="#table_MACRO">Table Macro</a>
-                                            </span>
-                                        </p>
+                                    <p>
+                                        <a id="para_12345" shape="rect"></a>
+                                        <span class="italic">Include <a class="xref" href="#table_MACRO" title="Table MACRO. Some Macro Attributes" shape="rect">Table MACRO “Some Macro Attributes”</a>
+                                        </span>
+                                    </p>
                                     </td>
                                 </tr>
                             </tbody>

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -504,6 +504,30 @@ def test_parse_table_include_row_name_prefix(table_include_dom):  # noqa: F811
     assert children[2].name.startswith(expected_prefix), \
         f"Include node name '{children[2].name}' does not start with '{expected_prefix}'"
 
+def test_parse_table_include_row_text_extraction(table_include_dom):  # noqa: F811
+    """Include row (colspan=4) extracts plain text when recursion disabled (include_depth=0)."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3", 3: "col4"}
+    node = parser.parse_table(
+        dom=table_include_dom,
+        table_id="table_MAIN",
+        column_to_attr=column_to_attr,
+        name_attr="col1",
+        include_depth=0  # disable recursion so include row becomes its own node
+    )
+    children = list(node.children)
+    # The root should have 3 children: AttrName1, AttrName2, Include
+    assert len(children) == 3
+    include_row = children[2]
+    text = include_row.col1
+    # Basic content checks
+    assert "Include Table MACRO" in text
+    assert "Some Macro Attributes" in text
+    # No HTML tags
+    assert "<" not in text and ">" not in text
+    # Gaps collapsed (no double blank lines)
+    assert "\n\n" not in text
+
 def test_parse_metadata_realigns_column_to_attr_when_middle_missing(docbook_sample_dom_1):  # noqa: F811
     """Test that parse realigns the metadata column_to_attr values when a column (e.g., elem_type) is missing."""
     parser = DOMTableSpecParser()

--- a/tests/test_dom_table_spec_parser.py
+++ b/tests/test_dom_table_spec_parser.py
@@ -484,8 +484,28 @@ def test_parse_table_include_missing_table(table_include_dom):  # noqa: F811
             name_attr="col1"
         )
 
+def test_parse_table_include_row_name_prefix(table_include_dom):  # noqa: F811
+    """Test that parse with include_depth equals 0 produce a node whose name starts with 'include_table'."""
+    parser = DOMTableSpecParser()
+    column_to_attr = {0: "col1", 1: "col2", 2: "col3", 3: "col4"}
+    node = parser.parse_table(
+        dom=table_include_dom,
+        table_id="table_MAIN",
+        column_to_attr=column_to_attr,
+        name_attr="col1",
+        include_depth=0
+    )
+    children = list(node.children)
+    # The root should have 3 children: AttrName1, AttrName2, Include
+    assert len(children) == 3
+    assert children[0].col1 == "AttrName1"
+    assert children[1].col1 == "AttrName2"    
+    expected_prefix = "include_table"
+    assert children[2].name.startswith(expected_prefix), \
+        f"Include node name '{children[2].name}' does not start with '{expected_prefix}'"
+
 def test_parse_metadata_realigns_column_to_attr_when_middle_missing(docbook_sample_dom_1):  # noqa: F811
-    """Test that parse realigns the metadata column_to_attr values when a middle column (e.g., elem_type) is missing."""
+    """Test that parse realigns the metadata column_to_attr values when a column (e.g., elem_type) is missing."""
     parser = DOMTableSpecParser()
     # Simulate a mapping where index 2 (elem_type) is missing, but index 3 (elem_desc) is present
     column_to_attr = {0: "elem_name", 1: "elem_tag", 3: "elem_desc"}

--- a/tests/test_iod_spec_printer.py
+++ b/tests/test_iod_spec_printer.py
@@ -264,11 +264,11 @@ def test_print_xlsx_colorize(iod_spec_model, tmp_path):
 
     wb = load_workbook(str(output_file))
     ws = wb["Patient"]
-    # Data row should have a fill color (LEVEL_COLORS[0])
+    # Data row should have a fill color
     fill_rgb = ws.cell(row=2, column=1).fill.start_color.rgb
     assert fill_rgb is not None
-    # LEVEL_COLORS[0] is "rgb(176,224,230)" → hex "B0E0E6"
-    assert fill_rgb == "FF87CEFA"
+    # Fill color should correspond Nesting Level 0: Powder Blue (hex #B0E0E6)
+    assert fill_rgb == "FFB0E0E6"  # openpyxl uses ARGB with 'FF' alpha channel
 
 def test_print_xlsx_multiple_modules(iod_spec_model, tmp_path):
     """Test that print_xlsx creates a worksheet for each module, including duplicates."""

--- a/tests/test_iod_spec_printer.py
+++ b/tests/test_iod_spec_printer.py
@@ -309,3 +309,8 @@ def test_print_xlsx_multiple_modules(iod_spec_model, tmp_path):
     assert ws_series.cell(row=2, column=1).value == "Series1"
     assert ws_patient_1.cell(row=2, column=1).value == "PatientX"
 
+def test_print_xlsx_raises_without_output_path(iod_spec_model):
+    """Test that print_xlsx raises ValueError if output path is not specified."""
+    printer = IODSpecPrinter(iod_spec_model)
+    with pytest.raises(ValueError):
+        printer.print_xlsx()

--- a/tests/test_iod_spec_printer.py
+++ b/tests/test_iod_spec_printer.py
@@ -1,7 +1,9 @@
 """Tests for the IODSpecPrinter class in dcmspec.iod_spec_printer."""
 import pytest
+
 from anytree import Node
-from rich.console import Console
+from openpyxl import load_workbook
+
 from dcmspec.iod_spec_printer import IODSpecPrinter
 from dcmspec.spec_model import SpecModel
 
@@ -26,12 +28,216 @@ def iod_spec_model():
     model._is_title = lambda node: False
     return model
 
+def set_attr1_with_quote(model):
+    """Set attr1 to a value with a quote for all attribute nodes in the model."""
+    for node in model.content.descendants:
+        if hasattr(node, "attr1"):
+            node.attr1 = 'Val"ue1'
+
+def _capture_print(outputs):
+    """Return a function that appends the first argument (text) to outputs when called.
+
+    Useful for monkeypatching printer.console.print to capture printed text in tests.
+    """
+    def capture_print(text, *args, **kwargs):
+        outputs.append(text)
+    return capture_print
+
+def _capture_style(styles, orig_print):
+    """Return a function that appends the 'style' kwarg to styles and calls the original print.
+
+    Useful for monkeypatching printer.console.print to capture style arguments in tests.
+    """
+    def capture_style(*args, **kwargs):
+        style = kwargs.get("style", None)
+        styles.append(style)
+        return orig_print(*args, **kwargs)
+    return capture_style
+
 def test_print_table_prints_module_title_and_attr(iod_spec_model):
     """Test that module title and attribute values are present in the output."""
     printer = IODSpecPrinter(iod_spec_model)
+    # Using printer.console.capture() is sufficient here because we only need to capture the rendered text output.
+    # Patching is not necessary unless we want to inspect styles or other print arguments.
     with printer.console.capture() as capture:
         printer.print_table(colorize=False)
     result = capture.get()
+    # Check for module title and attribute values
     assert "Patient Module (M)" in result
     assert "Value1" in result
     assert "Value2" in result
+
+def test_print_table_column_widths(iod_spec_model):
+    """Test that print_table applies column_widths for column sizing."""
+    printer = IODSpecPrinter(iod_spec_model)
+    # Capture the console output
+    with printer.console.capture() as capture:
+        printer.print_table(column_widths=[5, 2], colorize=False)
+    result = capture.get()
+    # Check that the headers and values are truncated/padded according to specified widths.
+    # Rich will pad or truncate headers and cell values to fit the specified column widths.
+    # If the content is too wide for the column, Rich truncates it and appends a Unicode ellipsis (…).
+    # If the content is shorter than the column width, Rich pads it with spaces.
+    assert "Attr1" in result
+    assert "A…" in result  # "Attr2" truncated to 2 chars
+    assert "Valu…" in result  # "Value1" truncated to 5 chars
+    assert "Va" in result  # "Value2" truncated to 2 chars
+
+def test_print_table_no_color_styles(iod_spec_model, monkeypatch):
+    """Test that print_table does not apply color styles when colorize=False."""
+    printer = IODSpecPrinter(iod_spec_model)
+    styles = []
+    # Patch printer.console.print to intercept and record the 'style' argument for each print call.
+    monkeypatch.setattr(printer.console, "print", _capture_style(styles, printer.console.print))
+    printer.print_table(colorize=False)
+    # All styles should be None or default
+    assert all(s in (None, "default", "") for s in styles)
+
+def test_print_tree_prints_module_title_and_attr(iod_spec_model):
+    """Test that print_tree outputs the module title and attribute values."""
+    printer = IODSpecPrinter(iod_spec_model)
+    # Capture the console output
+    with printer.console.capture() as capture:
+        printer.print_tree(attr_names=["attr1", "attr2"], colorize=False)
+    result = capture.get()
+    # Check for module title and attribute values
+    assert "Patient Module (M)" in result
+    assert "Value1" in result
+    assert "Value2" in result
+
+def test_print_tree_handles_attr_names_and_widths(iod_spec_model):
+    """Test that print_tree respects attr_names and attr_widths."""
+    printer = IODSpecPrinter(iod_spec_model)
+    # Capture the console output
+    with printer.console.capture() as capture:
+        printer.print_tree(attr_names=["attr1", "attr2"], attr_widths=[2, 3], colorize=False)
+    result = capture.get()
+    # Check for module title and attribute values
+    # Should be truncated to, respectively, 2 and 3 characters
+    assert "Va Val" in result
+
+def test_print_tree_no_color_styles(iod_spec_model, monkeypatch):
+    """Test that print_tree does not apply color styles when colorize=False."""
+    printer = IODSpecPrinter(iod_spec_model)
+    styles = []
+    # Patch printer.console.print to intercept and record the 'style' argument for each print call.
+    monkeypatch.setattr(printer.console, "print", _capture_style(styles, printer.console.print))
+    printer.print_tree(colorize=False)
+    assert all(s in ("default", None, "") for s in styles)
+
+def test_print_csv_prints_module_title_and_attr(iod_spec_model, monkeypatch):
+    """Test that print_csv outputs the module title and attribute values as CSV."""
+    printer = IODSpecPrinter(iod_spec_model)
+    outputs = []
+    # Patch printer.console.print to capture printed lines
+    monkeypatch.setattr(printer.console, "print", _capture_print(outputs))
+    printer.print_csv(colorize=False)
+    # The first line is the header, the second is the module title row, the third is the attribute row
+    assert outputs[0] == '"Attr1","Attr2"'
+    assert '"Patient Module (M)",""' in outputs  # Module title row
+    assert '"Value1","Value2"' in outputs        # Attribute row
+
+def test_print_csv_escapes_quotes(iod_spec_model, monkeypatch):
+    """Test that print_csv escapes quotes in CSV output."""
+    set_attr1_with_quote(iod_spec_model)
+    printer = IODSpecPrinter(iod_spec_model)
+    outputs = []
+    # Patch printer.console.print to capture printed lines
+    monkeypatch.setattr(printer.console, "print", _capture_print(outputs))
+    printer.print_csv(colorize=False)
+    assert any('Val""ue1' in line for line in outputs)
+
+def test_print_csv_no_color_styles(iod_spec_model, monkeypatch):
+    """Test that print_csv does not apply color styles when colorize=False."""
+    printer = IODSpecPrinter(iod_spec_model)
+    styles = []
+    # Patch printer.console.print to capture printed lines
+    monkeypatch.setattr(printer.console, "print", _capture_style(styles, printer.console.print))
+    printer.print_csv(colorize=False)
+    # All styles should be None
+    assert all(s is None for s in styles)
+
+def test_print_xlsx_basic(iod_spec_model, tmp_path):
+    """Test that print_xlsx writes header and one data row to a worksheet named after the module."""
+    output_file = tmp_path / "iod_out.xlsx"
+    printer = IODSpecPrinter(iod_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=False)
+
+    wb = load_workbook(str(output_file))
+    # Should be a single worksheet named "Patient"
+    assert "Patient" in wb.sheetnames
+    ws = wb["Patient"]
+    # Header values
+    assert ws.cell(row=1, column=1).value == "Attr1"
+    assert ws.cell(row=1, column=2).value == "Attr2"
+    # Data row values
+    assert ws.cell(row=2, column=1).value == "Value1"
+    assert ws.cell(row=2, column=2).value == "Value2"
+    # No fill when colorize=False
+    assert ws.cell(row=2, column=1).fill.patternType in (None, "solid")
+
+def test_print_xlsx_column_widths(iod_spec_model, tmp_path):
+    """Test that print_xlsx applies column widths to the worksheet."""
+    output_file = tmp_path / "iod_colwidths.xlsx"
+    printer = IODSpecPrinter(iod_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=False, column_widths=[15, 8])
+
+    wb = load_workbook(str(output_file))
+    ws = wb["Patient"]
+    # openpyxl may round column widths, so allow a small tolerance
+    assert abs(ws.column_dimensions['A'].width - 15) < 0.5
+    assert abs(ws.column_dimensions['B'].width - 8) < 0.5
+
+def test_print_xlsx_colorize(iod_spec_model, tmp_path):
+    """Test that print_xlsx applies color fill to attribute rows when colorize=True."""
+    output_file = tmp_path / "iod_color.xlsx"
+    printer = IODSpecPrinter(iod_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=True)
+
+    wb = load_workbook(str(output_file))
+    ws = wb["Patient"]
+    # Data row should have a fill color (LEVEL_COLORS[0])
+    fill_rgb = ws.cell(row=2, column=1).fill.start_color.rgb
+    assert fill_rgb is not None
+    # LEVEL_COLORS[0] is "rgb(176,224,230)" → hex "B0E0E6"
+    assert fill_rgb == "FF87CEFA"
+
+def test_print_xlsx_multiple_modules(iod_spec_model, tmp_path):
+    """Test that print_xlsx creates a worksheet for each module, including duplicates."""
+    content = iod_spec_model.content
+
+    # Add a second module with a different name
+    module_node2 = Node("module2", parent=content)
+    setattr(module_node2, "module", "Series")
+    setattr(module_node2, "usage", "M")
+    attr_node2 = Node("attr2", parent=module_node2)
+    setattr(attr_node2, "attr1", "Series1")
+    setattr(attr_node2, "attr2", "Series2")
+
+    # Add a third module with the same name as the first
+    module_node3 = Node("module3", parent=content)
+    setattr(module_node3, "module", "Patient")
+    setattr(module_node3, "usage", "M")
+    attr_node3 = Node("attr3", parent=module_node3)
+    setattr(attr_node3, "attr1", "PatientX")
+    setattr(attr_node3, "attr2", "PatientY")
+
+    output_file = tmp_path / "iod_multi_modules.xlsx"
+    printer = IODSpecPrinter(iod_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=False)
+
+    wb = load_workbook(str(output_file))
+    # Should have three sheets: "Patient", "Series", "Patient_1"
+    assert "Patient" in wb.sheetnames
+    assert "Series" in wb.sheetnames
+    assert "Patient_1" in wb.sheetnames
+
+    ws_patient = wb["Patient"]
+    ws_series = wb["Series"]
+    ws_patient_1 = wb["Patient_1"]
+
+    # Check that the data is in the correct sheets
+    assert ws_patient.cell(row=2, column=1).value == "Value1"
+    assert ws_series.cell(row=2, column=1).value == "Series1"
+    assert ws_patient_1.cell(row=2, column=1).value == "PatientX"
+

--- a/tests/test_iod_spec_printer.py
+++ b/tests/test_iod_spec_printer.py
@@ -93,6 +93,32 @@ def test_print_table_no_color_styles(iod_spec_model, monkeypatch):
     # All styles should be None or default
     assert all(s in (None, "default", "") for s in styles)
 
+def test_print_table_no_color_when_output_set(monkeypatch, iod_spec_model, tmp_path):
+    """Test that print_table sets style=None for all rows when output is set (writing to file)."""
+    # Prepare model
+    model = iod_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    
+    # Add two nodes
+    node2 = Node("element2", parent=model.content)
+    setattr(node2, "elem_name", "Element2")
+    setattr(node2, "elem_tag", "(0101,0020)")
+    
+    # Simulate output being set
+    output_file = tmp_path / "output.txt"
+    printer = IODSpecPrinter(model, output=str(output_file))
+    
+    # Capture styles passed to Table.add_row
+    styles = []
+    monkeypatch.setattr(printer.console, "print", _capture_style(styles, printer.console.print))
+    
+    # Call method with colorize=True (should be ignored because output is set)
+    printer.print_table(colorize=True)
+    
+    # Assert that all styles are None (no color applied)
+    assert all(s is None for s in styles), f"Expected no color styles, got {styles}"
+
 def test_print_tree_prints_module_title_and_attr(iod_spec_model):
     """Test that print_tree outputs the module title and attribute values."""
     printer = IODSpecPrinter(iod_spec_model)
@@ -125,6 +151,29 @@ def test_print_tree_no_color_styles(iod_spec_model, monkeypatch):
     printer.print_tree(colorize=False)
     assert all(s in ("default", None, "") for s in styles)
 
+def test_print_tree_no_color_when_output_set(monkeypatch, iod_spec_model, tmp_path):
+    """Test that print_tree does not apply color styles when output is set (writing to file)."""
+    model = iod_spec_model
+    
+    # Simulate output being set (e.g., writing to a file)
+    output_file = tmp_path / "output.txt"
+    printer = IODSpecPrinter(model, output=str(output_file))
+    
+    styles = []
+    
+    # Patch printer.console.print to capture the style attribute
+    monkeypatch.setattr(
+        printer.console,
+        "print",
+        lambda text, *args, **kwargs: styles.append(getattr(text, "style", None)),
+    )
+    
+    printer.print_tree(colorize=True)  # Even if colorize=True, output disables it
+    
+    # Assert that no style was applied
+    assert all(style in (None, '') for style in styles), f"Expected no color styles, got {styles}"
+
+
 def test_print_csv_prints_module_title_and_attr(iod_spec_model, monkeypatch):
     """Test that print_csv outputs the module title and attribute values as CSV."""
     printer = IODSpecPrinter(iod_spec_model)
@@ -156,6 +205,25 @@ def test_print_csv_no_color_styles(iod_spec_model, monkeypatch):
     printer.print_csv(colorize=False)
     # All styles should be None
     assert all(s is None for s in styles)
+
+def test_print_csv_no_color_when_output_set(monkeypatch, iod_spec_model, tmp_path):
+    """Test that print_csv sets style=None for all rows when output is set (writing to file)."""
+    # Prepare model
+    model = iod_spec_model
+
+    # Simulate output being set
+    output_file = tmp_path / "output.csv"
+    printer = IODSpecPrinter(model, output=str(output_file))
+
+    # Capture styles from console.print
+    styles = []
+    monkeypatch.setattr(printer.console, "print", _capture_style(styles, printer.console.print))
+
+    # Call method with colorize=True (should be ignored because output is set)
+    printer.print_csv(colorize=True)
+
+    # Header + data rows should all have style=None
+    assert all(s in (None, '') for s in styles), f"Unexpected non-None styles: {styles}"
 
 def test_print_xlsx_basic(iod_spec_model, tmp_path):
     """Test that print_xlsx writes header and one data row to a worksheet named after the module."""

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -310,6 +310,32 @@ def test_select_tables_multirow_header_simple():
     assert selected[0]["data"][0] == ["1", "2", "3", "4", "5"]
     assert selected[0]["data"][1] == ["6", "7", "8", "9", "10"]
 
+def test_select_tables_raises_on_tag_in_header():
+    """Fail loudly when a data row is absorbed into the header.
+
+    Mirrors the real IHE-RO TPPC-Brachy page-35 failure: table_header_rowspan=2
+    over-counts the header, so the "Application Setup Sequence" attribute row
+    (tag 300A,0230) is merged into the header and silently dropped. select_tables
+    must raise rather than warn-and-drop — silent attribute loss is unacceptable
+    for conformance tooling.
+    """
+    # Arrange
+    handler = make_handler()
+    rows = [
+        ["Attribute", "Tag", "Type", "Presence", "Specific Rules"],
+        ["Application Setup Sequence", "(300A,0230)", "1", "R+*", "Number of items shall be 1."],
+        [">Application Setup Type", "(300A,0232)", "1", "-*", ""],
+    ]
+    tables = [{"page": 35, "index": 0, "data": rows}]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"DICOM tag pattern"):
+        handler.select_tables(
+            tables,
+            table_indices=[(35, 0)],
+            table_header_rowspan={(35, 0): 2},
+        )
+
 def test_concat_tables_basic(monkeypatch, patch_dirs):
     """Test concat_tables concatenates tables with matching headers."""
     # Arrange

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -336,6 +336,33 @@ def test_select_tables_raises_on_tag_in_header():
             table_header_rowspan={(35, 0): 2},
         )
 
+def test_select_tables_skips_guard_when_not_strict():
+    """strict_header_check=False opts out of the tag-in-header guard.
+
+    Same absorbed-header input as the strict test, but the consumer has opted out:
+    select_tables returns normally (the prior warn-and-continue behavior) instead of raising.
+    """
+    # Arrange
+    handler = make_handler()
+    rows = [
+        ["Attribute", "Tag", "Type", "Presence", "Specific Rules"],
+        ["Application Setup Sequence", "(300A,0230)", "1", "R+*", "Number of items shall be 1."],
+        [">Application Setup Type", "(300A,0232)", "1", "-*", ""],
+    ]
+    tables = [{"page": 35, "index": 0, "data": rows}]
+
+    # Act — opted out, so no raise
+    selected = handler.select_tables(
+        tables,
+        table_indices=[(35, 0)],
+        table_header_rowspan={(35, 0): 2},
+        strict_header_check=False,
+    )
+
+    # Assert
+    assert len(selected) == 1
+    assert selected[0]["page"] == 35
+
 def test_concat_tables_basic(monkeypatch, patch_dirs):
     """Test concat_tables concatenates tables with matching headers."""
     # Arrange

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -634,10 +634,10 @@ def test_print_xlsx_colorize_and_column_widths(minimal_spec_model, tmp_path):
     assert abs(ws.column_dimensions['B'].width - 15) < 0.5
     assert abs(ws.column_dimensions['C'].width - 8) < 0.5
 
-    # Color fill applied: depth 1 → LEVEL_COLORS[0] rgb(176,224,230) → hex B0E0E6 (openpyxl stores ARGB)
+    # Fill color should correspond Nesting Level 0: Powder Blue (hex #B0E0E6)
     fill_rgb = ws.cell(row=2, column=1).fill.start_color.rgb
     assert fill_rgb is not None
-    assert fill_rgb.endswith("B0E0E6")
+    assert fill_rgb == "FFB0E0E6"  # openpyxl uses ARGB with 'FF' alpha channel
 
 def test_print_xlsx_include_and_title_colors(minimal_spec_model, tmp_path):
     """Test that XLSX export uses SPECIAL_COLORS for include and title rows when colorized."""

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -170,6 +170,29 @@ def test_print_tree_no_color(monkeypatch, minimal_spec_model):
     # All styles should be "default" or None (Rich may use None for no style)
     assert all(s in ("default", None, "") for s in styles), f"Unexpected styles: {styles}"
     
+def test_print_tree_no_color_when_output_set(monkeypatch, minimal_spec_model, tmp_path):
+    """Test that print_tree does not apply color styles when output is set (writing to file)."""
+    model = minimal_spec_model
+    add_standard_node(model)
+    
+    # Simulate output being set (e.g., writing to a file)
+    output_file = tmp_path / "output.txt"
+    printer = SpecPrinter(model, output=str(output_file))
+    
+    styles = []
+    
+    # Patch printer.console.print to capture the style attribute
+    monkeypatch.setattr(
+        printer.console,
+        "print",
+        lambda text, *args, **kwargs: styles.append(getattr(text, "style", None)),
+    )
+    
+    printer.print_tree(colorize=True)  # Even if colorize=True, output disables it
+    
+    # Assert that no style was applied
+    assert all(style in (None, '') for style in styles), f"Expected no color styles, got {styles}"
+
 def test_print_table_does_not_crash(monkeypatch, minimal_spec_model):
     """Test that print_table can be called without error."""
     model = minimal_spec_model
@@ -253,6 +276,34 @@ def test_print_table_no_color(monkeypatch, minimal_spec_model):
     printer.print_table(colorize=False)
     # All add_row calls should have style=None
     assert all(s is None for s in styles)
+
+def test_print_table_no_color_when_output_set(monkeypatch, minimal_spec_model, tmp_path):
+    """Test that print_table sets style=None for all rows when output is set (writing to file)."""
+    # Prepare model
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    
+    # Add two nodes
+    add_standard_node(model)
+    node2 = Node("element2", parent=model.content)
+    setattr(node2, "elem_name", "Element2")
+    setattr(node2, "elem_tag", "(0101,0020)")
+    
+    # Simulate output being set
+    output_file = tmp_path / "output.txt"
+    printer = SpecPrinter(model, output=str(output_file))
+    
+    # Capture styles passed to Table.add_row
+    styles = []
+    monkeypatch.setattr("rich.table.Table.add_row", mock_table_add_row_capture_styles(styles))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
+    
+    # Call method with colorize=True (should be ignored because output is set)
+    printer.print_table(colorize=True)
+    
+    # Assert that all styles are None (no color applied)
+    assert all(s is None for s in styles), f"Expected no color styles, got {styles}"
 
 def test_print_table_column_widths(monkeypatch, minimal_spec_model):
     """Test that print_table applies column_widths for column sizing."""
@@ -432,6 +483,28 @@ def test_print_csv_no_color(monkeypatch, minimal_spec_model):
     printer.print_csv(colorize=False)
     # Header + data rows all should have style None
     assert all(s is None for s in styles), f"Unexpected non-None styles: {styles}"
+
+def test_print_csv_no_color_when_output_set(monkeypatch, minimal_spec_model, tmp_path):
+    """Test that print_csv sets style=None for all rows when output is set (writing to file)."""
+    # Prepare model
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    add_standard_node(model)
+
+    # Simulate output being set
+    output_file = tmp_path / "output.csv"
+    printer = SpecPrinter(model, output=str(output_file))
+
+    # Capture styles from console.print
+    styles = []
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_styles(styles))
+
+    # Call method with colorize=True (should be ignored because output is set)
+    printer.print_csv(colorize=True)
+
+    # Header + data rows should all have style=None
+    assert all(s in (None, '') for s in styles), f"Unexpected non-None styles: {styles}"
 
 def test_print_csv_quote_escaping(monkeypatch, minimal_spec_model):
     """Test that print_csv properly escapes quotes in CSV output."""

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -110,16 +110,6 @@ def test_print_table_empty_header(monkeypatch, minimal_spec_model):
     monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
     printer.print_table()
 
-def test_print_table_empty_column_to_attr(monkeypatch, minimal_spec_model):
-    """Test that print_table works when metadata.column_to_attr is empty."""
-    model = minimal_spec_model
-    model.metadata.header = ["Name", "Tag"]
-    add_standard_node(model)  # Adds a node and sets column_to_attr
-    model.metadata.column_to_attr = {}  # Clear columns after adding the node
-    printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
-    printer.print_table()
-
 def test_print_csv_empty_column_to_attr(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -525,11 +525,11 @@ def test_output_file_closed_on_delete(minimal_spec_model, tmp_path):
     assert file_obj.closed
 
 def test_print_xlsx_basic(minimal_spec_model, tmp_path):
-    """Basic XLSX export: header and one data row written."""
+    """Test that XLSX export writes header and one data row."""
     add_standard_node(minimal_spec_model)
     output_file = tmp_path / "out.xlsx"
-    printer = SpecPrinter(minimal_spec_model)
-    printer.print_xlsx(output=str(output_file), colorize=False)
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=False)
 
     wb = load_workbook(str(output_file))
     ws = wb.active
@@ -543,15 +543,15 @@ def test_print_xlsx_basic(minimal_spec_model, tmp_path):
     assert ws.cell(row=2, column=1).fill.patternType in (None, "solid")  # may default to solid without color
 
 def test_print_xlsx_colorize_and_column_widths(minimal_spec_model, tmp_path):
-    """XLSX export applies color fill and column widths."""
+    """Test that XLSX export applies color fill and column widths."""
     node = add_standard_node(minimal_spec_model)
     # Add a third column
     minimal_spec_model.metadata.header = ["Name", "Tag", "Type"]
     minimal_spec_model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type"}
     setattr(node, "elem_type", "1")
     output_file = tmp_path / "styled.xlsx"
-    printer = SpecPrinter(minimal_spec_model)
-    printer.print_xlsx(output=str(output_file), colorize=True, column_widths=[25, 15, 8])
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=True, column_widths=[25, 15, 8])
 
     wb = load_workbook(str(output_file))
     ws = wb.active
@@ -566,7 +566,59 @@ def test_print_xlsx_colorize_and_column_widths(minimal_spec_model, tmp_path):
     assert fill_rgb is not None
     assert fill_rgb.endswith("B0E0E6")
 
+def test_print_xlsx_include_and_title_colors(minimal_spec_model, tmp_path):
+    """Test that XLSX export uses SPECIAL_COLORS for include and title rows when colorized."""
+    # Setup: header and column mapping
+    minimal_spec_model.metadata.header = ["Name", "Tag"]
+    minimal_spec_model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
 
+    # Include node: elem_name contains "Include Table", node name starts with "include_table"
+    include_node = Node("include_table_macro", parent=minimal_spec_model.content)
+    setattr(include_node, "elem_name", "Include Table MACRO")
+    setattr(include_node, "elem_tag", "")
+
+    # Title node: all other attributes than elem_name must be either absent or None, node name can be anything
+    title_node = Node("title_node", parent=minimal_spec_model.content)
+    setattr(title_node, "elem_name", "Module Title")
+    # Do NOT set elem_tag
+
+    # Patch _is_title to return True for title_node only
+    minimal_spec_model._is_title = lambda node: node is title_node
+
+    # Add a standard node for control
+    standard_node = Node("element1", parent=minimal_spec_model.content)
+    setattr(standard_node, "elem_name", "Element1")
+    setattr(standard_node, "elem_tag", "(0101,0010)")
+
+    output_file = tmp_path / "styled_include_title.xlsx"
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_xlsx(colorize=True)
+
+    wb = load_workbook(str(output_file))
+    ws = wb.active
+
+    # Row 2: include node, Row 3: title node, Row 4: standard node
+    include_fill = ws.cell(row=2, column=1).fill
+    title_fill = ws.cell(row=3, column=1).fill
+    standard_fill = ws.cell(row=4, column=1).fill
+
+    def rgb_to_hex(rgb_str):
+        rgb = rgb_str.replace("rgb(", "").replace(")", "").split(",")
+        return "FF{:02X}{:02X}{:02X}".format(*map(int, rgb))
+
+    # openpyxl stores colors in ARGB format (e.g., "FFRRGGBB") either in fgColor or start_color
+    include_color = (include_fill.fgColor.rgb or include_fill.start_color.rgb or "").lower()
+    title_color = (title_fill.fgColor.rgb or title_fill.start_color.rgb or "").lower()
+    standard_color = (standard_fill.fgColor.rgb or standard_fill.start_color.rgb or "").lower()
+
+    expected_include_rgb = rgb_to_hex(SPECIAL_COLORS["include"]).lower()
+    expected_title_rgb = rgb_to_hex(SPECIAL_COLORS["title"]).lower()
+    expected_level_rgb = rgb_to_hex(LEVEL_COLORS[0]).lower()
+
+    # Assert that the applied colors end with the expected RGB hex (ignoring the ARGB alpha prefix)
+    assert include_color.endswith(expected_include_rgb)
+    assert title_color.endswith(expected_title_rgb)
+    assert standard_color.endswith(expected_level_rgb)
 
 
 

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -693,5 +693,9 @@ def test_print_xlsx_include_and_title_colors(minimal_spec_model, tmp_path):
     assert title_color.endswith(expected_title_rgb)
     assert standard_color.endswith(expected_level_rgb)
 
-
+def test_print_xlsx_raises_without_output_path(minimal_spec_model):
+    """Test that print_xlsx raises ValueError if output path is not specified."""
+    printer = SpecPrinter(minimal_spec_model)
+    with pytest.raises(ValueError):
+        printer.print_xlsx()
 

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -1,4 +1,5 @@
 """Tests for the SpecPrinter class in dcmspec.spec_model."""
+import gc
 import logging
 import pytest
 from anytree import Node
@@ -396,6 +397,7 @@ def test_output_file_closed_on_delete(minimal_spec_model, tmp_path):
     printer = SpecPrinter(minimal_spec_model, output=str(output_file))
     file_obj = printer.console.file
     del printer
+    gc.collect()  # Force garbage collection so __del__ runs
     assert file_obj.closed
 
 

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -114,11 +114,23 @@ def test_print_table_empty_column_to_attr(monkeypatch, minimal_spec_model):
     """Test that print_table works when metadata.column_to_attr is empty."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
-    model.metadata.column_to_attr = {}  # Explicitly set column_to_attr to empty for clarity
-    add_standard_node(model)
+    add_standard_node(model)  # Adds a node and sets column_to_attr
+    model.metadata.column_to_attr = {}  # Clear columns after adding the node
     printer = SpecPrinter(model)
     monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
     printer.print_table()
+
+def test_print_csv_empty_column_to_attr(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    add_standard_node(model)  # Adds a node and sets column_to_attr
+    model.metadata.column_to_attr = {}  # Clear columns after adding the node
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    # Only header expected (rows have no columns -> empty row skipped)
+    assert len(outputs) == 1
 
 def test_print_table_node_missing_attribute(monkeypatch, minimal_spec_model):
     """Test that print_table handles nodes missing an attribute defined in column_to_attr."""
@@ -195,6 +207,158 @@ def test_print_table_no_color(monkeypatch, minimal_spec_model):
     printer.print_table(colorize=False)
     # All add_row calls should have style=None
     assert all(s is None for s in styles)
+
+def test_print_csv_does_not_crash(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    add_standard_node(model)
+    printer = SpecPrinter(model)
+    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    printer.print_csv()
+
+def test_print_csv_nominal(monkeypatch, minimal_spec_model):
+    """Nominal CSV output: header + one data row with expected quoted values."""
+    model = minimal_spec_model
+    add_standard_node(model)  # sets header and column_to_attr
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    assert len(outputs) == 2, f"Unexpected output lines: {outputs}"
+    assert outputs[0] == '"Name","Tag"'
+    assert outputs[1] == '"Element1","(0101,0010)"'
+
+def test_print_csv_multiline_field(monkeypatch, minimal_spec_model):
+    """CSV preserves embedded newlines inside quoted fields."""
+    model = minimal_spec_model
+    node = add_standard_node(model)
+    setattr(node, "elem_name", "Element1 line1\nline2")
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    assert outputs[0] == '"Name","Tag"'
+    # Newline remains inside the quoted field
+    assert outputs[1] == '"Element1 line1\nline2","(0101,0010)"'
+
+def test_print_csv_empty_header(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = []
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    add_standard_node(model)
+    printer = SpecPrinter(model)
+    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    printer.print_csv()
+
+def test_print_csv_empty_column_to_attr(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    add_standard_node(model)  # Adds a node and sets column_to_attr
+    model.metadata.column_to_attr = {}  # Clear columns after adding the node
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    # Only header expected (rows have no columns -> empty row skipped)
+    assert len(outputs) == 1
+
+def test_print_csv_node_missing_attribute(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    add_standard_node(model, with_elem_tag=False)
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    # Header + one row
+    assert len(outputs) == 2
+    # Missing elem_tag should yield an empty quoted field
+    assert outputs[1].endswith(',""') or ',""' in outputs[1]
+
+def test_print_csv_row_style(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+
+    include_node = Node("include_table_macro", parent=model.content)
+    setattr(include_node, "elem_name", "Include Item")
+    setattr(include_node, "elem_tag", "(0101,1001)")
+
+    title_node = Node("title_node", parent=model.content)
+    setattr(title_node, "elem_name", "Title Item")
+    setattr(title_node, "elem_tag", "(0101,1002)")
+    model._is_title = lambda n: n is title_node  # Patch title logic
+
+    standard = add_standard_node(model)
+
+    printer = SpecPrinter(model)
+    styles = []
+
+    def capture(text, *a, **k):
+        styles.append(k.get("style"))
+    monkeypatch.setattr(printer.console, "print", capture)
+
+    printer.print_csv(colorize=True)
+
+    # First style corresponds to header (None), following to rows
+    row_styles = [s for s in styles[1:] if s is not None]
+    assert "yellow" in row_styles
+    assert "magenta" in row_styles
+    assert any(
+        s in [
+            "rgb(255,255,255)",
+            "rgb(173,216,230)",
+            "rgb(135,206,250)",
+            "rgb(0,191,255)",
+            "rgb(30,144,255)",
+            "rgb(0,0,255)",
+        ]
+        for s in row_styles
+    )
+
+def test_print_csv_no_color(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    add_standard_node(model)
+    printer = SpecPrinter(model)  # FIX: instantiate printer before monkeypatch
+    styles = []
+    monkeypatch.setattr(
+        printer.console,
+        "print",
+        lambda text, *a, **k: styles.append(k.get("style")),
+    )
+    printer.print_csv(colorize=False)
+    # Header + data rows all should have style None
+    assert all(s is None for s in styles), f"Unexpected non-None styles: {styles}"
+
+def test_print_csv_quote_escaping(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    node = add_standard_node(model)
+    setattr(node, "elem_name", 'Element "Quoted" Name')
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    # Row should have doubled internal quotes
+    data_rows = outputs[1:]
+    assert any('Element ""Quoted"" Name' in r for r in data_rows)
+
+def test_print_csv_skips_empty_rows(monkeypatch, minimal_spec_model):
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    node = add_standard_node(model)
+    setattr(node, "elem_name", " ")
+    setattr(node, "elem_tag", " ")
+    printer = SpecPrinter(model)
+    outputs = []
+    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    printer.print_csv()
+    # Only header printed because row is empty (whitespace)
+    assert len(outputs) == 1
 
 
 

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -338,6 +338,66 @@ def test_print_csv_skips_empty_rows(monkeypatch, minimal_spec_model):
     # Only header printed because row is empty (whitespace)
     assert len(outputs) == 1
 
+def test_init_with_output_file(minimal_spec_model, tmp_path):
+    """Test that SpecPrinter initializes with an output file path."""
+    output_file = tmp_path / "output.txt"
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    assert printer.output == str(output_file)
+    assert printer.console.file is not None
+    # Clean up
+    del printer
+
+def test_print_tree_to_file(minimal_spec_model, tmp_path):
+    """Test that print_tree writes plain text to file without colors."""
+    output_file = tmp_path / "tree_output.txt"
+    add_standard_node(minimal_spec_model)
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_tree(attr_names="elem_name", colorize=True)
+    del printer  # Ensure file is closed
+    
+    content = output_file.read_text(encoding="utf-8")
+    assert "Element1" in content
+    # Tree drawing characters should be present
+    assert "└──" in content or "├──" in content
+    # Verify no ANSI color codes (RGB sequences won't be in plain text)
+    assert "\x1b[" not in content
+
+def test_print_table_to_file(minimal_spec_model, tmp_path):
+    """Test that print_table writes plain text to file without colors."""
+    output_file = tmp_path / "table_output.txt"
+    add_standard_node(minimal_spec_model)
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_table(colorize=True)
+    del printer
+    
+    content = output_file.read_text()
+    assert "Element1" in content
+    assert "(0101,0010)" in content
+    assert "\x1b[" not in content
+
+def test_print_csv_to_file(minimal_spec_model, tmp_path):
+    """Test that print_csv writes CSV to file without colors."""
+    output_file = tmp_path / "csv_output.csv"
+    add_standard_node(minimal_spec_model)
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    printer.print_csv(colorize=True)
+    del printer
+    
+    content = output_file.read_text()
+    lines = content.strip().split("\n")
+    assert len(lines) == 2  # Header + 1 data row
+    assert lines[0] == '"Name","Tag"'
+    assert lines[1] == '"Element1","(0101,0010)"'
+    assert "\x1b[" not in content
+
+def test_output_file_closed_on_delete(minimal_spec_model, tmp_path):
+    """Test that output file is properly closed when printer is deleted."""
+    output_file = tmp_path / "closed_test.txt"
+    printer = SpecPrinter(minimal_spec_model, output=str(output_file))
+    file_obj = printer.console.file
+    del printer
+    assert file_obj.closed
+
 
 
 

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -110,18 +110,6 @@ def test_print_table_empty_header(monkeypatch, minimal_spec_model):
     monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
     printer.print_table()
 
-def test_print_csv_empty_column_to_attr(monkeypatch, minimal_spec_model):
-    model = minimal_spec_model
-    model.metadata.header = ["Name", "Tag"]
-    add_standard_node(model)  # Adds a node and sets column_to_attr
-    model.metadata.column_to_attr = {}  # Clear columns after adding the node
-    printer = SpecPrinter(model)
-    outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
-    printer.print_csv()
-    # Only header expected (rows have no columns -> empty row skipped)
-    assert len(outputs) == 1
-
 def test_print_table_node_missing_attribute(monkeypatch, minimal_spec_model):
     """Test that print_table handles nodes missing an attribute defined in column_to_attr."""
     model = minimal_spec_model

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -6,6 +6,80 @@ from anytree import Node
 from dcmspec.spec_model import SpecModel
 from dcmspec.spec_printer import SpecPrinter
 
+# Mock functions for testing
+def mock_console_print_no_op(*args, **kwargs):
+    """Mock console.print that does nothing.
+    
+    Args:
+        *args: Positional arguments
+        **kwargs: Keyword arguments 
+
+    Returns:
+        None
+
+    """
+    pass
+
+def mock_table_add_row_capture_styles(styles_list):
+    """Create a mock Table.add_row that captures styles.
+    
+    Args:
+        styles_list: List to capture style values
+
+    Returns:
+        Mock function that captures styles
+
+    """
+    def _mock(*args, style=None, **kwargs):
+        styles_list.append(style)
+    return _mock
+
+def mock_table_add_column_capture_widths(widths_list):
+    """Create a mock Table.add_column that captures width arguments.
+    
+    Args:
+        widths_list: List to capture width values
+        
+    Returns:
+        Mock function that captures widths and calls original add_column
+
+    """
+    from rich.table import Table
+    original_add_column = Table.add_column
+    
+    def _mock(self, header, width=None, **kwargs):
+        widths_list.append(width)
+        return original_add_column(self, header, width=width, **kwargs)
+    return _mock
+
+def mock_console_print_capture_text(outputs_list):
+    """Create a mock console.print that captures text output.
+    
+    Args:
+        outputs_list: List to capture text output
+        
+    Returns:
+        Mock function that captures text output
+
+    """
+    def _mock(text, *args, **kwargs):
+        outputs_list.append(text)
+    return _mock
+
+def mock_console_print_capture_styles(styles_list):
+    """Create a mock console.print that captures style kwargs.
+    
+    Args:
+        styles_list: List to capture style values
+        
+    Returns:
+        Mock function that captures styles and calls original add_column
+
+    """
+    def _mock(text, *args, **kwargs):
+        styles_list.append(kwargs.get('style'))
+    return _mock
+
 @pytest.fixture
 def minimal_spec_model():
     """Create a minimal SpecModel with empty metadata and content nodes."""
@@ -43,7 +117,7 @@ def test_print_tree_does_not_crash(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_tree()
 
 def test_print_tree_node_missing_attribute(monkeypatch, minimal_spec_model):
@@ -51,7 +125,7 @@ def test_print_tree_node_missing_attribute(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     add_standard_node(model, with_elem_tag=False)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     # Should not raise, should print empty string for missing attribute
     printer.print_tree(attr_names=["elem_name", "elem_tag"])
 
@@ -60,7 +134,7 @@ def test_print_tree_attr_names_string_and_list(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     # attr_names as string
     printer.print_tree(attr_names="elem_name")
     # attr_names as list
@@ -71,7 +145,7 @@ def test_print_tree_attr_widths(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     # attr_widths: elem_name padded to 5, elem_tag padded to 2
     printer.print_tree(attr_names=["elem_name", "elem_tag"], attr_widths=[5, 2])
 
@@ -98,7 +172,7 @@ def test_print_table_does_not_crash(monkeypatch, minimal_spec_model):
     model = minimal_spec_model
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_table()
 
 def test_print_table_empty_header(monkeypatch, minimal_spec_model):
@@ -108,7 +182,7 @@ def test_print_table_empty_header(monkeypatch, minimal_spec_model):
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_table()
 
 def test_print_table_node_missing_attribute(monkeypatch, minimal_spec_model):
@@ -118,7 +192,7 @@ def test_print_table_node_missing_attribute(monkeypatch, minimal_spec_model):
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
     add_standard_node(model, with_elem_tag=False)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     # Should not raise, should print empty string for missing attribute
     printer.print_table()
 
@@ -147,9 +221,9 @@ def test_print_table_row_style(monkeypatch, minimal_spec_model):
     styles = []
 
     # Patch Table.add_row
-    monkeypatch.setattr("rich.table.Table.add_row", lambda *args, style=None, **kwargs: styles.append(style))
+    monkeypatch.setattr("rich.table.Table.add_row", mock_table_add_row_capture_styles(styles))
     # Patch console.print to avoid output
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
 
     printer.print_table(colorize=True)
 
@@ -181,17 +255,83 @@ def test_print_table_no_color(monkeypatch, minimal_spec_model):
     printer = SpecPrinter(model)
     # Patch Table.add_row to track calls
     styles = []
-    monkeypatch.setattr("rich.table.Table.add_row", lambda *args, style=None, **kwargs: styles.append(style))
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr("rich.table.Table.add_row", mock_table_add_row_capture_styles(styles))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_table(colorize=False)
     # All add_row calls should have style=None
     assert all(s is None for s in styles)
 
+def test_print_table_column_widths(monkeypatch, minimal_spec_model):
+    """Test that print_table applies column_widths for column sizing."""
+    model = minimal_spec_model
+    node = add_standard_node(model)
+    # Set headers AFTER add_standard_node to avoid them being overwritten
+    model.metadata.header = ["Name", "Tag", "Type"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type"}
+    setattr(node, "elem_type", "1")
+    
+    printer = SpecPrinter(model)
+    
+    # Capture column widths
+    column_widths_used = []
+    from rich.table import Table
+    monkeypatch.setattr(Table, "add_column", mock_table_add_column_capture_widths(column_widths_used))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
+    
+    printer.print_table(column_widths=[30, 15, 5])
+    
+    # Verify the widths were applied correctly
+    assert column_widths_used == [30, 15, 5]
+
+def test_print_table_column_widths_default(monkeypatch, minimal_spec_model):
+    """Test that print_table uses default width 20 when column_widths is None."""
+    model = minimal_spec_model
+    model.metadata.header = ["Name", "Tag"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
+    add_standard_node(model)
+    
+    printer = SpecPrinter(model)
+    
+    # Capture column widths
+    column_widths_used = []
+    from rich.table import Table
+    monkeypatch.setattr(Table, "add_column", mock_table_add_column_capture_widths(column_widths_used))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
+    
+    printer.print_table()  # No column_widths specified
+    
+    # All columns should use default width of 20
+    assert column_widths_used == [20, 20]
+
+def test_print_table_column_widths_partial(monkeypatch, minimal_spec_model):
+    """Test that print_table falls back to default width for unspecified columns."""
+    model = minimal_spec_model
+    node = add_standard_node(model)
+    # Set headers AFTER add_standard_node to avoid them being overwritten
+    model.metadata.header = ["Name", "Tag", "Type"]
+    model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type"}
+    setattr(node, "elem_type", "1")
+    
+    printer = SpecPrinter(model)
+    
+    # Capture column widths
+    column_widths_used = []
+    from rich.table import Table
+    monkeypatch.setattr(Table, "add_column", mock_table_add_column_capture_widths(column_widths_used))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
+    
+    # Only specify width for first two columns
+    printer.print_table(column_widths=[25, 10])
+    
+    # First two columns use specified widths, third falls back to default
+    assert column_widths_used == [25, 10, 20]
+
 def test_print_csv_does_not_crash(monkeypatch, minimal_spec_model):
+    """Test that print_csv can be called without error."""
     model = minimal_spec_model
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_csv()
 
 def test_print_csv_nominal(monkeypatch, minimal_spec_model):
@@ -200,7 +340,7 @@ def test_print_csv_nominal(monkeypatch, minimal_spec_model):
     add_standard_node(model)  # sets header and column_to_attr
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     assert len(outputs) == 2, f"Unexpected output lines: {outputs}"
     assert outputs[0] == '"Name","Tag"'
@@ -213,41 +353,44 @@ def test_print_csv_multiline_field(monkeypatch, minimal_spec_model):
     setattr(node, "elem_name", "Element1 line1\nline2")
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     assert outputs[0] == '"Name","Tag"'
     # Newline remains inside the quoted field
     assert outputs[1] == '"Element1 line1\nline2","(0101,0010)"'
 
 def test_print_csv_empty_header(monkeypatch, minimal_spec_model):
+    """Test that print_csv works when metadata.header is empty."""
     model = minimal_spec_model
     model.metadata.header = []
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
     add_standard_node(model)
     printer = SpecPrinter(model)
-    monkeypatch.setattr(printer.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_no_op)
     printer.print_csv()
 
 def test_print_csv_empty_column_to_attr(monkeypatch, minimal_spec_model):
+    """Test that print_csv handles empty column_to_attr correctly."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     add_standard_node(model)  # Adds a node and sets column_to_attr
     model.metadata.column_to_attr = {}  # Clear columns after adding the node
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     # Only header expected (rows have no columns -> empty row skipped)
     assert len(outputs) == 1
 
 def test_print_csv_node_missing_attribute(monkeypatch, minimal_spec_model):
+    """Test that print_csv handles nodes missing an attribute."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
     add_standard_node(model, with_elem_tag=False)
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     # Header + one row
     assert len(outputs) == 2
@@ -255,10 +398,12 @@ def test_print_csv_node_missing_attribute(monkeypatch, minimal_spec_model):
     assert outputs[1].endswith(',""') or ',""' in outputs[1]
 
 def test_print_csv_row_style(monkeypatch, minimal_spec_model):
+    """Test that print_csv sets the correct row style for different node types."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
 
+    # sourcery skip: extract-duplicate-method
     include_node = Node("include_table_macro", parent=model.content)
     setattr(include_node, "elem_name", "Include Item")
     setattr(include_node, "elem_tag", "(0101,1001)")
@@ -268,14 +413,12 @@ def test_print_csv_row_style(monkeypatch, minimal_spec_model):
     setattr(title_node, "elem_tag", "(0101,1002)")
     model._is_title = lambda n: n is title_node  # Patch title logic
 
-    standard = add_standard_node(model)
+    add_standard_node(model)
 
     printer = SpecPrinter(model)
     styles = []
 
-    def capture(text, *a, **k):
-        styles.append(k.get("style"))
-    monkeypatch.setattr(printer.console, "print", capture)
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_styles(styles))
 
     printer.print_csv(colorize=True)
 
@@ -296,22 +439,20 @@ def test_print_csv_row_style(monkeypatch, minimal_spec_model):
     )
 
 def test_print_csv_no_color(monkeypatch, minimal_spec_model):
+    """Test that print_csv sets style=None for all rows when colorize=False."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
     add_standard_node(model)
-    printer = SpecPrinter(model)  # FIX: instantiate printer before monkeypatch
+    printer = SpecPrinter(model)
     styles = []
-    monkeypatch.setattr(
-        printer.console,
-        "print",
-        lambda text, *a, **k: styles.append(k.get("style")),
-    )
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_styles(styles))
     printer.print_csv(colorize=False)
     # Header + data rows all should have style None
     assert all(s is None for s in styles), f"Unexpected non-None styles: {styles}"
 
 def test_print_csv_quote_escaping(monkeypatch, minimal_spec_model):
+    """Test that print_csv properly escapes quotes in CSV output."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
@@ -319,13 +460,14 @@ def test_print_csv_quote_escaping(monkeypatch, minimal_spec_model):
     setattr(node, "elem_name", 'Element "Quoted" Name')
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     # Row should have doubled internal quotes
     data_rows = outputs[1:]
     assert any('Element ""Quoted"" Name' in r for r in data_rows)
 
 def test_print_csv_skips_empty_rows(monkeypatch, minimal_spec_model):
+    """Test that print_csv skips rows with only whitespace."""
     model = minimal_spec_model
     model.metadata.header = ["Name", "Tag"]
     model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag"}
@@ -334,7 +476,7 @@ def test_print_csv_skips_empty_rows(monkeypatch, minimal_spec_model):
     setattr(node, "elem_tag", " ")
     printer = SpecPrinter(model)
     outputs = []
-    monkeypatch.setattr(printer.console, "print", lambda text, *a, **k: outputs.append(text))
+    monkeypatch.setattr(printer.console, "print", mock_console_print_capture_text(outputs))
     printer.print_csv()
     # Only header printed because row is empty (whitespace)
     assert len(outputs) == 1

--- a/tests/test_spec_printer.py
+++ b/tests/test_spec_printer.py
@@ -2,9 +2,12 @@
 import gc
 import logging
 import pytest
+
 from anytree import Node
+from openpyxl import load_workbook
+
 from dcmspec.spec_model import SpecModel
-from dcmspec.spec_printer import SpecPrinter
+from dcmspec.spec_printer import SpecPrinter, SPECIAL_COLORS, LEVEL_COLORS
 
 # Mock functions for testing
 def mock_console_print_no_op(*args, **kwargs):
@@ -227,20 +230,10 @@ def test_print_table_row_style(monkeypatch, minimal_spec_model):
 
     printer.print_table(colorize=True)
 
-    # The order is: include_node, title_node, default_node (since PreOrderIter)
-    assert "yellow" in styles
-    assert "magenta" in styles
-    assert any(
-        s in styles
-        for s in [
-            "rgb(255,255,255)",
-            "rgb(173,216,230)",
-            "rgb(135,206,250)",
-            "rgb(0,191,255)",
-            "rgb(30,144,255)",
-            "rgb(0,0,255)",
-        ]
-    )
+    # The order is: include_node, title_node, default_node
+    assert SPECIAL_COLORS["include"] in styles
+    assert SPECIAL_COLORS["title"] in styles
+    assert any(s in LEVEL_COLORS for s in styles)
 
 def test_print_table_no_color(monkeypatch, minimal_spec_model):
     """Test that print_table sets style=None for all rows when colorize=False."""
@@ -422,21 +415,10 @@ def test_print_csv_row_style(monkeypatch, minimal_spec_model):
 
     printer.print_csv(colorize=True)
 
-    # First style corresponds to header (None), following to rows
     row_styles = [s for s in styles[1:] if s is not None]
-    assert "yellow" in row_styles
-    assert "magenta" in row_styles
-    assert any(
-        s in [
-            "rgb(255,255,255)",
-            "rgb(173,216,230)",
-            "rgb(135,206,250)",
-            "rgb(0,191,255)",
-            "rgb(30,144,255)",
-            "rgb(0,0,255)",
-        ]
-        for s in row_styles
-    )
+    assert SPECIAL_COLORS["include"] in row_styles
+    assert SPECIAL_COLORS["title"] in row_styles
+    assert any(s in LEVEL_COLORS for s in row_styles)
 
 def test_print_csv_no_color(monkeypatch, minimal_spec_model):
     """Test that print_csv sets style=None for all rows when colorize=False."""
@@ -542,7 +524,47 @@ def test_output_file_closed_on_delete(minimal_spec_model, tmp_path):
     gc.collect()  # Force garbage collection so __del__ runs
     assert file_obj.closed
 
+def test_print_xlsx_basic(minimal_spec_model, tmp_path):
+    """Basic XLSX export: header and one data row written."""
+    add_standard_node(minimal_spec_model)
+    output_file = tmp_path / "out.xlsx"
+    printer = SpecPrinter(minimal_spec_model)
+    printer.print_xlsx(output=str(output_file), colorize=False)
 
+    wb = load_workbook(str(output_file))
+    ws = wb.active
+    # Header values
+    assert ws.cell(row=1, column=1).value == "Name"
+    assert ws.cell(row=1, column=2).value == "Tag"
+    # Data row values
+    assert ws.cell(row=2, column=1).value == "Element1"
+    assert ws.cell(row=2, column=2).value == "(0101,0010)"
+    # No fill when colorize=False
+    assert ws.cell(row=2, column=1).fill.patternType in (None, "solid")  # may default to solid without color
+
+def test_print_xlsx_colorize_and_column_widths(minimal_spec_model, tmp_path):
+    """XLSX export applies color fill and column widths."""
+    node = add_standard_node(minimal_spec_model)
+    # Add a third column
+    minimal_spec_model.metadata.header = ["Name", "Tag", "Type"]
+    minimal_spec_model.metadata.column_to_attr = {0: "elem_name", 1: "elem_tag", 2: "elem_type"}
+    setattr(node, "elem_type", "1")
+    output_file = tmp_path / "styled.xlsx"
+    printer = SpecPrinter(minimal_spec_model)
+    printer.print_xlsx(output=str(output_file), colorize=True, column_widths=[25, 15, 8])
+
+    wb = load_workbook(str(output_file))
+    ws = wb.active
+
+    # Verify column widths (rounded by Excel; allow tolerance)
+    assert abs(ws.column_dimensions['A'].width - 25) < 0.5
+    assert abs(ws.column_dimensions['B'].width - 15) < 0.5
+    assert abs(ws.column_dimensions['C'].width - 8) < 0.5
+
+    # Color fill applied: depth 1 → LEVEL_COLORS[0] rgb(176,224,230) → hex B0E0E6 (openpyxl stores ARGB)
+    fill_rgb = ws.cell(row=2, column=1).fill.start_color.rgb
+    assert fill_rgb is not None
+    assert fill_rgb.endswith("B0E0E6")
 
 
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] This PR targets the correct branch (`main`, `release/x.y.z`, etc.)
- [x] I have reviewed the changes and they are ready for review.
- [x] I have added or updated tests for my changes (if applicable).
- [x] I have updated documentation as needed.

## Description

select_tables splits the first table_header_rowspan rows of each table as the header and merges them. When that rowspan is one too large, the first real attribute row is silently merged into the header and dropped from the parsed specification — only a 'Header mismatch' warning is emitted later.

For IHE-RO conformance tooling this is a serious failure mode: a non-emitted attribute means the spec is silently incomplete, which can let a non-conformant object pass validation. Observed on TPPC-Brachy pages 35-37, where 'Application Setup Sequence' (300A,0230) and two other parent rows were lost.

Detect a DICOM tag pattern (gggg,eeee) in a header cell — a strong signal a data row was absorbed — and raise ValueError naming the page/index and the likely cause (table_header_rowspan exceeding the actual header rows), instead of silently dropping the row.

Adds a regression test reproducing the TPPC-Brachy page-35 case.

ValueError Documented in the docstring for select_tables in pdf_doc_handler.py

## Summary by Sourcery

Add richer output formats and stricter table parsing safeguards while improving CLI ergonomics and documentation.

New Features:
- Introduce CSV and Excel (OOXML) export capabilities for specification models via SpecPrinter and IODSpecPrinter, including configurable column widths and file output.
- Add support in the modattributes and iodattributes CLIs for selecting print modes (table, tree, csv, xlsx) and directing output to files with optional colorization control.
- Detect DICOM tag patterns in table headers during PDF table selection and raise a ValueError when a data row is likely absorbed into the header, with an option to disable the strict check.

Bug Fixes:
- Prevent silent loss of attribute rows by failing loudly when a DICOM tag appears in a table header due to misconfigured header row spans.
- Improve include-table row handling and node naming in DOMTableSpecParser so include rows generate stable, sanitized node names and clean plain-text content.
- Ensure SpecPrinter and IODSpecPrinter handle empty or missing node attributes and whitespace-only rows gracefully in all output modes.

Enhancements:
- Refactor SpecPrinter and IODSpecPrinter to centralize row iteration and styling logic, support file-backed Console instances, and consistently disable colors for file outputs.
- Extend tree and table color schemes with clearer level-based and special-row colors for better readability across console and Excel outputs.
- Use html2text-based extraction and stronger text cleaning and sanitization when parsing table cells to produce more readable and robust attribute names.
- Expand IOD Excel export to emit one worksheet per module with safe, de-duplicated sheet names.

Build:
- Bump project version to 0.3.0 and add html2text and openpyxl as runtime dependencies for improved text extraction and Excel export support.

Documentation:
- Document new CSV and Excel output modes, output file handling, and colorization options in the modattributes and iodattributes CLI guides.
- Update RELEASE.md with a more detailed release workflow, GitHub tagging guidance, and Zenodo badge update steps.
- Refresh README badges, including switching the PyPI badge provider and updating the Zenodo DOI.

Tests:
- Add comprehensive tests for SpecPrinter and IODSpecPrinter covering tree, table, CSV, and Excel output, color behavior, column widths, and file lifecycle.
- Add regression tests for absorbed-header detection in PDFDocHandler and for include-row parsing, naming, and text extraction in DOMTableSpecParser.