### PR TITLE
Fail loudly when a data row is absorbed into a table header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ These release notes summarize key changes, improvements, and breaking updates fo
 
 ## [0.4.0] - unreleased
 
+### Added
+
+- `PDFDocHandler.select_tables` now raises `ValueError` when a header cell contains a DICOM tag pattern (e.g. `(300A,0230)`), indicating that a data row was absorbed into the header — typically a `table_header_rowspan` over-count. This fails loudly instead of silently dropping an attribute row. Opt out with `strict_header_check=False` to restore the prior warn-and-continue behavior.
+
 ### Changed
 
 - Switch PyPI version badge in README from badge.fury.io to shields.io for faster updates.

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -5,6 +5,7 @@ from IHE Technical Frameworks or Supplements, returning CSV data from tables in 
 """
 
 import os
+import re
 import logging
 from typing import Optional, List
 # BEGIN LEGACY SUPPORT: Remove for int progress callback deprecation
@@ -18,6 +19,14 @@ import camelot
 from dcmspec.config import Config
 from dcmspec.doc_handler import DocHandler
 from dcmspec.progress import ProgressObserver
+
+# A DICOM tag pattern like "(300A,0230)" appearing in a *header* cell is a strong
+# signal that a data (attribute) row was absorbed into the header — typically
+# because table_header_rowspan over-counts the header rows for a table.
+# select_tables uses this to fail loudly rather than silently drop the row, which
+# is unacceptable for conformance tooling.
+_DICOM_TAG_RE = re.compile(r"\(\s*[0-9A-Fa-f]{4}\s*,\s*[0-9A-Fa-f]{4}\s*\)")
+
 
 class PDFDocHandler(DocHandler):
     """Handler class for extracting tables from PDF documents.
@@ -317,6 +326,19 @@ class PDFDocHandler(DocHandler):
                         header_ = header_rows[0]
                     else:
                         header_ = merge_multirow_header(header_rows)
+                    # Fail loudly if a data row was absorbed into the header: a
+                    # DICOM tag pattern in a header cell means table_header_rowspan
+                    # likely over-counts the header rows for this table, which would
+                    # otherwise silently drop a real attribute row from the spec.
+                    for cell in header_:
+                        if cell and _DICOM_TAG_RE.search(str(cell)):
+                            raise ValueError(
+                                f"Header for table (page {page}, index {idx}) contains a "
+                                f"DICOM tag pattern in cell {cell!r}; a data row was likely "
+                                f"absorbed into the header. Check table_header_rowspan for "
+                                f"(page {page}, index {idx}) — it may exceed the actual "
+                                f"number of header rows."
+                            )
                     selected_tables.append({
                         "page": page,
                         "index": idx,

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -288,6 +288,12 @@ class PDFDocHandler(DocHandler):
                 - 'header': merged header row (list of column names)
                 - 'data': list of data rows (list of cell values)
 
+        Raises:
+            ValueError: If a header cell contains a DICOM tag pattern (e.g. "(300A,0230)"),
+                indicating that a data row was absorbed into the header — typically because
+                table_header_rowspan over-counts the header rows for that table. Failing loudly
+                here prevents silently dropping a real attribute row from the specification.
+
         Example:
             ```python
             selected_tables = handler.select_tables(

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -28,6 +28,36 @@ from dcmspec.progress import ProgressObserver
 _DICOM_TAG_RE = re.compile(r"\(\s*[0-9A-Fa-f]{4}\s*,\s*[0-9A-Fa-f]{4}\s*\)")
 
 
+def _assert_no_dicom_tag_in_header(header_: List, page: int, idx: int) -> None:
+    """Raise if a header cell contains a DICOM tag pattern (data row absorbed into the header).
+
+    Uses a substring search, not a whole-cell match: when ``table_header_rowspan`` over-counts
+    and fuses an absorbed attribute row into the header, the tag ends up embedded in a larger
+    cell (e.g. ``"Tag (300A,0230)"``), so anchoring the pattern to the whole cell would miss the
+    very corruption this guards against. Header cells in DICOM spec tables are short column
+    titles, so a legitimate cell carrying a parenthesized hex pattern is not expected; if one
+    ever does, pass ``strict_header_check=False``.
+
+    Args:
+        header_ (List): The merged header row (list of cell values).
+        page (int): Page number of the table (for the error message).
+        idx (int): Index of the table on the page (for the error message).
+
+    Raises:
+        ValueError: If any header cell contains a DICOM tag pattern.
+
+    """
+    for cell in header_:
+        if cell and _DICOM_TAG_RE.search(str(cell)):
+            raise ValueError(
+                f"Header for table (page {page}, index {idx}) contains a "
+                f"DICOM tag pattern in cell {cell!r}; a data row was likely "
+                f"absorbed into the header. Check table_header_rowspan for "
+                f"(page {page}, index {idx}) — it may exceed the actual "
+                f"number of header rows."
+            )
+
+
 class PDFDocHandler(DocHandler):
     """Handler class for extracting tables from PDF documents.
 
@@ -344,15 +374,7 @@ class PDFDocHandler(DocHandler):
                     # otherwise silently drop a real attribute row from the spec.
                     # Opt out with strict_header_check=False to keep the prior behavior.
                     if strict_header_check:
-                        for cell in header_:
-                            if cell and _DICOM_TAG_RE.search(str(cell)):
-                                raise ValueError(
-                                    f"Header for table (page {page}, index {idx}) contains a "
-                                    f"DICOM tag pattern in cell {cell!r}; a data row was likely "
-                                    f"absorbed into the header. Check table_header_rowspan for "
-                                    f"(page {page}, index {idx}) — it may exceed the actual "
-                                    f"number of header rows."
-                                )
+                        _assert_no_dicom_tag_in_header(header_, page, idx)
                     selected_tables.append({
                         "page": page,
                         "index": idx,

--- a/src/dcmspec/pdf_doc_handler.py
+++ b/src/dcmspec/pdf_doc_handler.py
@@ -267,6 +267,7 @@ class PDFDocHandler(DocHandler):
         tables: List[dict],
         table_indices: List[tuple],
         table_header_rowspan: Optional[dict] = None,
+        strict_header_check: bool = True,
     ) -> List[dict]:
         """Select tables referenced by table_indices and split each table into header and data.
 
@@ -280,6 +281,10 @@ class PDFDocHandler(DocHandler):
             table_indices (List[tuple]): List of (page, index) tuples specifying which tables to select and process.
             table_header_rowspan (dict, optional): Number of header rows (rowspan) for each table in table_indices,
                 keyed by (page, index). If not specified, defaults to 1 header row per table.
+            strict_header_check (bool): If True (default), raise ValueError when a header cell
+                contains a DICOM tag pattern — a sign that a data row was absorbed into the header
+                (usually a table_header_rowspan that over-counts the header rows). Set False to skip
+                the check for consumers that prefer the prior warn-and-continue behavior.
 
         Returns:
             List[dict]: List of dicts, each with keys:
@@ -289,7 +294,8 @@ class PDFDocHandler(DocHandler):
                 - 'data': list of data rows (list of cell values)
 
         Raises:
-            ValueError: If a header cell contains a DICOM tag pattern (e.g. "(300A,0230)"),
+            ValueError: If strict_header_check is True (default) and a header cell contains a DICOM
+                tag pattern (e.g. "(300A,0230)"),
                 indicating that a data row was absorbed into the header — typically because
                 table_header_rowspan over-counts the header rows for that table. Failing loudly
                 here prevents silently dropping a real attribute row from the specification.
@@ -336,15 +342,17 @@ class PDFDocHandler(DocHandler):
                     # DICOM tag pattern in a header cell means table_header_rowspan
                     # likely over-counts the header rows for this table, which would
                     # otherwise silently drop a real attribute row from the spec.
-                    for cell in header_:
-                        if cell and _DICOM_TAG_RE.search(str(cell)):
-                            raise ValueError(
-                                f"Header for table (page {page}, index {idx}) contains a "
-                                f"DICOM tag pattern in cell {cell!r}; a data row was likely "
-                                f"absorbed into the header. Check table_header_rowspan for "
-                                f"(page {page}, index {idx}) — it may exceed the actual "
-                                f"number of header rows."
-                            )
+                    # Opt out with strict_header_check=False to keep the prior behavior.
+                    if strict_header_check:
+                        for cell in header_:
+                            if cell and _DICOM_TAG_RE.search(str(cell)):
+                                raise ValueError(
+                                    f"Header for table (page {page}, index {idx}) contains a "
+                                    f"DICOM tag pattern in cell {cell!r}; a data row was likely "
+                                    f"absorbed into the header. Check table_header_rowspan for "
+                                    f"(page {page}, index {idx}) — it may exceed the actual "
+                                    f"number of header rows."
+                                )
                     selected_tables.append({
                         "page": page,
                         "index": idx,

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -329,12 +329,20 @@ def test_select_tables_raises_on_tag_in_header():
     tables = [{"page": 35, "index": 0, "data": rows}]
 
     # Act / Assert
-    with pytest.raises(ValueError, match=r"DICOM tag pattern"):
+    with pytest.raises(ValueError) as excinfo:
         handler.select_tables(
             tables,
             table_indices=[(35, 0)],
             table_header_rowspan={(35, 0): 2},
         )
+    # The failure must stay ACTIONABLE: it names the table (page/index) and the
+    # offending cell, not just a generic "DICOM tag pattern". Pin that context so a
+    # regression toward a less actionable message is caught.
+    msg = str(excinfo.value)
+    assert "DICOM tag pattern" in msg
+    assert "page 35" in msg
+    assert "index 0" in msg
+    assert "(300A,0230)" in msg
 
 def test_select_tables_skips_guard_when_not_strict():
     """strict_header_check=False opts out of the tag-in-header guard.

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -310,6 +310,32 @@ def test_select_tables_multirow_header_simple():
     assert selected[0]["data"][0] == ["1", "2", "3", "4", "5"]
     assert selected[0]["data"][1] == ["6", "7", "8", "9", "10"]
 
+def test_select_tables_raises_on_tag_in_header():
+    """Fail loudly when a data row is absorbed into the header.
+
+    Mirrors the real IHE-RO TPPC-Brachy page-35 failure: table_header_rowspan=2
+    over-counts the header, so the "Application Setup Sequence" attribute row
+    (tag 300A,0230) is merged into the header and silently dropped. select_tables
+    must raise rather than warn-and-drop — silent attribute loss is unacceptable
+    for conformance tooling.
+    """
+    # Arrange
+    handler = make_handler()
+    rows = [
+        ["Attribute", "Tag", "Type", "Presence", "Specific Rules"],
+        ["Application Setup Sequence", "(300A,0230)", "1", "R+*", "Number of items shall be 1."],
+        [">Application Setup Type", "(300A,0232)", "1", "-*", ""],
+    ]
+    tables = [{"page": 35, "index": 0, "data": rows}]
+
+    # Act / Assert
+    with pytest.raises(ValueError, match=r"DICOM tag pattern"):
+        handler.select_tables(
+            tables,
+            table_indices=[(35, 0)],
+            table_header_rowspan={(35, 0): 2},
+        )
+
 def test_concat_tables_basic(monkeypatch, patch_dirs):
     """Test concat_tables concatenates tables with matching headers."""
     # Arrange

--- a/tests/test_pdf_doc_handler.py
+++ b/tests/test_pdf_doc_handler.py
@@ -336,6 +336,33 @@ def test_select_tables_raises_on_tag_in_header():
             table_header_rowspan={(35, 0): 2},
         )
 
+def test_select_tables_skips_guard_when_not_strict():
+    """strict_header_check=False opts out of the tag-in-header guard.
+
+    Same absorbed-header input as the strict test, but the consumer has opted out:
+    select_tables returns normally (the prior warn-and-continue behavior) instead of raising.
+    """
+    # Arrange
+    handler = make_handler()
+    rows = [
+        ["Attribute", "Tag", "Type", "Presence", "Specific Rules"],
+        ["Application Setup Sequence", "(300A,0230)", "1", "R+*", "Number of items shall be 1."],
+        [">Application Setup Type", "(300A,0232)", "1", "-*", ""],
+    ]
+    tables = [{"page": 35, "index": 0, "data": rows}]
+
+    # Act — opted out, so no raise
+    selected = handler.select_tables(
+        tables,
+        table_indices=[(35, 0)],
+        table_header_rowspan={(35, 0): 2},
+        strict_header_check=False,
+    )
+
+    # Assert
+    assert len(selected) == 1
+    assert selected[0]["page"] == 35
+
 def test_concat_tables_basic(monkeypatch, patch_dirs):
     """Test concat_tables concatenates tables with matching headers."""
     # Arrange


### PR DESCRIPTION
Pull Request Checklist

 [x] This PR targets the correct branch (main, release/x.y.z, etc.)
 [x] I have reviewed the changes and they are ready for review.
 [x] I have added or updated tests for my changes (if applicable).
 [x] I have updated documentation as needed.

## Fail loudly when a data row is absorbed into a table header

`PDFDocHandler.select_tables` can silently drop a real attribute row when `table_header_rowspan` over-counts the header rows for a table: a data row gets merged into the header and only a "Header mismatch" warning is emitted downstream. For conformance tooling, silently losing an attribute row is unacceptable.

This change makes `select_tables` **fail loudly**: if a header cell contains a DICOM tag pattern (e.g. `(300A,0230)`) — a strong signal that a data row was absorbed into the header — it raises `ValueError` instead of continuing.

### Configurable
- `strict_header_check: bool = True` (default) — raise on a tag-in-header.
- `strict_header_check=False` — restore the prior warn-and-continue behavior for consumers that prefer it.

The check is dormant on well-formed tables (a correct header carries no DICOM tag), so it's a safety net that only fires on the exact corruption it targets.

### Changes
- `select_tables`: the guard + the `strict_header_check` parameter, with `Raises:` documented in the docstring (mkdocstrings renders the API page from it).
- Tests: `test_select_tables_raises_on_tag_in_header` and `test_select_tables_skips_guard_when_not_strict`. Full `test_pdf_doc_handler.py` suite passes (22).
- `CHANGELOG.md`: entry under `## [0.4.0]`.

### Base
Targets `release/0.4.0` per the project's git-flow. Cut cleanly from `release/0.4.0` — additions only, no conflicts. (Supersedes the closed #106, which targeted `main`, and #107, which conflicted because its branch was based on `main` and dragged in main's divergence.)

— vivian-1a61bc9a

## Summary by Sourcery

Fail loudly when table header parsing suggests a data row was absorbed into the header, while allowing opt-out for existing consumers.

New Features:
- Add a configurable strict_header_check option to PDFDocHandler.select_tables to raise when a header cell contains a DICOM tag pattern, indicating a likely absorbed data row.

Enhancements:
- Introduce a DICOM tag detection guard in select_tables headers to prevent silent loss of attribute rows during table extraction.

Documentation:
- Document the new strict_header_check behavior and error condition in the select_tables docstring and changelog entry for version 0.4.0.

Tests:
- Add tests covering ValueError raising on tag-in-header and the non-strict path that preserves the previous warn-and-continue behavior.